### PR TITLE
Add visual-explainer integration guide for complex plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ This plugin was built with insights from these articles, repositories, and tools
 - <https://github.com/tidewave-elixir/tidewave>
 - <https://tidewave.ai/blog/the-future-of-coding-agents-is-vertical-integration>
 - <https://github.com/neilberkman/ccrider>
+- <https://github.com/nicobailon/visual-explainer>
 - <https://github.com/VoltAgent/awesome-claude-code-subagents>
 - <https://github.com/shanraisshan/claude-code-best-practice>
 - <https://github.com/anthropics/claude-code>

--- a/plugins/elixir-phoenix/skills/brief/SKILL.md
+++ b/plugins/elixir-phoenix/skills/brief/SKILL.md
@@ -124,6 +124,12 @@ Consider `/phx:compound` to capture key learnings for future reference.
   create       understand before            execute        understand after
 ```
 
+## Complex Plan Enhancement
+
+For plans with 5+ phases or 4+ key decisions, consider suggesting
+visual rendering after Section 3. See
+`references/visual-explainer.md` for thresholds and commands.
+
 ## Notes
 
 - Runs in main conversation context (not a subagent)

--- a/plugins/elixir-phoenix/skills/brief/references/visual-explainer.md
+++ b/plugins/elixir-phoenix/skills/brief/references/visual-explainer.md
@@ -1,0 +1,62 @@
+# Visual Explainer Integration
+
+When a plan's complexity exceeds what terminal-based briefings handle
+well, consider generating a visual HTML artifact using the
+[visual-explainer](https://github.com/nicobailon/visual-explainer)
+skill.
+
+## When to Suggest Visual Output
+
+Suggest visual rendering when ANY of these apply:
+
+- Plan has **5+ phases** with cross-phase dependencies
+- Plan has **4+ key decisions** with competing trade-offs
+- Plan includes a **System Map** with 3+ pages and wiring
+- Post-work briefing shows **mixed completion** (some phases
+  blocked, others done) — progress burndown is clearer visually
+
+## What Visual-Explainer Provides
+
+| Cognitive Issue | Terminal Brief | Visual-Explainer |
+|----------------|---------------|-----------------|
+| Phase sequencing | Flat table | Mermaid flowchart with dependencies |
+| Decision trade-offs | Linear text per decision | CSS Grid constraint cards (pros/cons/rejected) |
+| Data model connections | Prose description | Entity diagrams with phase annotations |
+| Post-work progress | Text table with counts | Chart.js burndown / progress bars |
+| System Map wiring | Flat page list | Interactive Mermaid sequence diagram |
+
+## How to Suggest
+
+At the end of Section 3 (Solution Shape / How It Was Built), if
+complexity thresholds are met, add:
+
+```
+This plan has {N} phases with cross-dependencies.
+Want a visual diagram? Try: `/generate-visual-plan`
+(requires visual-explainer skill)
+```
+
+Keep it as a **suggestion only** — never block the briefing flow.
+The terminal briefing remains the primary output; visual rendering
+is a complement for complex cases.
+
+## Key Commands from Visual-Explainer
+
+- `/generate-visual-plan` — Render plan as styled HTML with Mermaid
+  phase flow diagrams and decision cards
+- `/generate-slides` — Magazine-quality slide deck of the briefing
+- `/diff-review --slides` — Visual diff analysis (pairs well with
+  post-work brief)
+- `/project-recap` — Context-switching snapshot (useful when
+  resuming work on a plan after time away)
+
+## Installation
+
+```bash
+# Via Claude Code
+# Clone to ~/.claude/skills/visual-explainer
+git clone https://github.com/nicobailon/visual-explainer ~/.claude/skills/visual-explainer
+```
+
+See the [visual-explainer README](https://github.com/nicobailon/visual-explainer)
+for full setup instructions.


### PR DESCRIPTION
## Summary

This PR adds documentation and guidance for integrating the visual-explainer skill into the Elixir Phoenix brief plugin, enabling visual rendering of complex plans that exceed terminal-based briefing capabilities.

## Key Changes

- **New reference guide** (`plugins/elixir-phoenix/skills/brief/references/visual-explainer.md`):
  - Documents when to suggest visual output (5+ phases, 4+ decisions, complex system maps, mixed completion states)
  - Provides comparison table showing cognitive advantages of visual rendering over terminal output
  - Lists key visual-explainer commands (`/generate-visual-plan`, `/generate-slides`, `/diff-review --slides`, `/project-recap`)
  - Includes installation instructions

- **Updated SKILL.md** (`plugins/elixir-phoenix/skills/brief/SKILL.md`):
  - Added "Complex Plan Enhancement" section directing users to the visual-explainer reference
  - Clarifies when to suggest visual rendering after Section 3 of briefings

- **Updated README.md**:
  - Added visual-explainer repository link to the references/inspiration section

## Implementation Details

The integration is designed as a **non-blocking suggestion** — visual rendering complements rather than replaces terminal briefings. The guidance provides clear thresholds for when complexity warrants visual output, helping users decide when to invoke visual-explainer commands for better comprehension of multi-phase plans with dependencies and trade-offs.

https://claude.ai/code/session_01LZsY9tFQPSLQbcCgewEhrh