### PR TITLE
Add /phx:permissions skill for session-based permission analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`/phx:permissions` skill** — Analyzes recent Claude Code sessions to identify
+  frequently-approved Bash commands, classifies them by risk (GREEN/YELLOW/RED),
+  and recommends safe additions to `settings.json`. Inspired by Intercom's
+  permission analyzer pattern. Includes 4 Iron Laws, `--days` and `--dry-run`
+  flags, and reference docs for risk classification and settings format
+
 ## [2.4.0] - 2026-03-19
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -620,6 +620,7 @@ When working on code, automatically consult relevant reference documentation bef
 | PR review comments | `/phx:pr-review` |
 | Performance analysis | `/phx:perf` |
 | Project health | `/phx:audit` |
+| Reduce permission prompts | `/phx:permissions` |
 | Scan sessions for metrics | `/session-scan` |
 | Deep-analyze sessions | `/session-deep-dive` |
 | View session trends | `/session-trends` |
@@ -630,7 +631,7 @@ When working on code, automatically consult relevant reference documentation bef
 
 **Review → Follow-up Plan**: After `/phx:review`, if findings reveal scope gaps or missing coverage, use `/phx:plan .claude/plans/{slug}/reviews/{review}.md` to create a follow-up plan from review output.
 
-**Standalone**: `/phx:quick`, `/phx:full`, `/phx:investigate`, `/phx:verify`, `/phx:research`
+**Standalone**: `/phx:quick`, `/phx:full`, `/phx:investigate`, `/phx:verify`, `/phx:research`, `/phx:permissions`
 
 **Analysis**: `/ecto:n1-check`, `/lv:assigns`, `/phx:boundaries`, `/phx:trace`, `/phx:techdebt`
 

--- a/plugins/elixir-phoenix/skills/permissions/SKILL.md
+++ b/plugins/elixir-phoenix/skills/permissions/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: phx:permissions
+description: Analyze recent Claude Code sessions and recommend safe Bash permissions for settings.json. Use when too many permission prompts slow the workflow, after 5+ permission prompts in a session, or when the user says "fix permissions", "reduce prompts", "allow commands", "permission fatigue", or "optimize permissions".
+argument-hint: [--days=14] [--dry-run]
+---
+
+# Permission Analyzer
+
+Analyze recent session history to identify frequently-approved Bash
+commands, classify them by risk, and write safe ones to `settings.json`.
+
+## Usage
+
+```
+/phx:permissions                # Analyze last 14 days, apply safe commands
+/phx:permissions --days=30      # Analyze last 30 days
+/phx:permissions --dry-run      # Show recommendations without applying
+```
+
+## Arguments
+
+`$ARGUMENTS` — Optional flags:
+
+- `--days=N` — How many days of history to scan (default: 14)
+- `--dry-run` — Preview recommendations without writing to settings.json
+
+## Iron Laws
+
+1. **Never auto-allow RED commands** — `rm`, `sudo`, `curl|wget` piped to shell, `chmod 777`, `kill -9`, `docker rm` require manual approval every time
+2. **Evidence-based only** — Only recommend commands the user has actually approved in recent sessions, never guess or suggest commands speculatively
+3. **Show before writing** — Always present the full proposed `settings.json` diff to the user and get explicit confirmation before modifying settings
+4. **Preserve existing permissions** — Merge with current settings, never overwrite user's manually configured permissions
+
+## Risk Classification
+
+| Level | Category | Examples | Action |
+|-------|----------|----------|--------|
+| GREEN | Read-only, tests | `ls`, `cat`, `grep`, `mix test`, `mix compile`, `mix format`, `mix credo`, `git status`, `git log`, `git diff` | Auto-recommend |
+| YELLOW | Writes, git ops | `git add`, `git commit`, `git push`, `mkdir`, `mix ecto.migrate`, `mix deps.get`, `npm install` | Recommend with note |
+| RED | Destructive | `rm`, `sudo`, `kill`, `curl\|sh`, `mix ecto.reset`, `git push --force`, `chmod` | Never recommend |
+
+## Workflow
+
+### Step 1: Parse `--days` and `--dry-run` from `$ARGUMENTS`
+
+Default: `--days=14`, `--dry-run=false`.
+
+### Step 2: Scan Session Transcripts
+
+Find recent sessions and extract approved Bash commands:
+
+```bash
+# Find session directories from last N days
+find ~/.claude/projects/ -name "*.jsonl" -mtime -${DAYS} 2>/dev/null
+
+# Also check for session transcripts
+find ~/.claude/ -name "transcript*.jsonl" -mtime -${DAYS} 2>/dev/null
+```
+
+Parse each session file for Bash tool calls that were approved
+(not denied). Extract the command string from each.
+
+### Step 3: Classify Commands
+
+For each unique command pattern:
+
+1. **Normalize** — Strip arguments to get the base command pattern
+   (e.g., `mix test test/foo_test.exs` → `mix test`)
+2. **Classify** — Assign GREEN / YELLOW / RED per the table above
+3. **Count** — Track approval frequency
+
+### Step 4: Read Current Settings
+
+```bash
+cat ~/.claude/settings.json 2>/dev/null || echo "{}"
+cat .claude/settings.json 2>/dev/null || echo "{}"
+cat .claude/settings.local.json 2>/dev/null || echo "{}"
+```
+
+Parse existing `allowedTools` to avoid duplicating.
+
+### Step 5: Generate Recommendations
+
+Present a table to the user:
+
+```
+## Permission Recommendations (last {N} days)
+
+### GREEN — Safe to allow (approved {X} times)
+| Command Pattern | Times Approved | Risk |
+|----------------|---------------|------|
+| mix test *     | 47            | GREEN |
+| mix compile *  | 32            | GREEN |
+| ...            |               |       |
+
+### YELLOW — Recommended with caution (approved {X} times)
+| Command Pattern | Times Approved | Risk | Note |
+|----------------|---------------|------|------|
+| git commit *   | 23            | YELLOW | Writes to repo |
+| ...            |               |        |       |
+
+### RED — Never auto-allowed (still require approval)
+| Command Pattern | Times Approved | Risk |
+|----------------|---------------|------|
+| rm -rf *       | 2             | RED  |
+```
+
+### Step 6: Apply (unless `--dry-run`)
+
+If user confirms, write GREEN + approved YELLOW commands to
+`.claude/settings.json` as `allowedTools` entries:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(mix test*)",
+      "Bash(mix compile*)",
+      "Bash(mix format*)",
+      "Bash(git status)",
+      "Bash(git diff*)",
+      "Bash(git log*)"
+    ]
+  }
+}
+```
+
+**Merge** with existing settings — never overwrite.
+
+### Step 7: Summary
+
+Report what was added, what was skipped (RED), and suggest
+re-running in 2-4 weeks as workflow evolves.
+
+## References
+
+- `references/risk-classification.md` — Full command classification rules
+- `references/settings-format.md` — Claude Code settings.json permission format

--- a/plugins/elixir-phoenix/skills/permissions/references/risk-classification.md
+++ b/plugins/elixir-phoenix/skills/permissions/references/risk-classification.md
@@ -1,0 +1,194 @@
+# Risk Classification Rules
+
+Comprehensive command classification for the permission analyzer.
+
+## Classification Algorithm
+
+1. Extract the **base command** (first token or first two tokens for compound commands)
+2. Check against RED list first (deny-list takes priority)
+3. Check against GREEN list
+4. Default to YELLOW if not in either list
+
+## GREEN — Read-Only and Standard Dev Tools
+
+Commands that cannot cause data loss or security issues.
+
+### Always Safe
+
+| Pattern | Rationale |
+|---------|-----------|
+| `ls *` | Read-only directory listing |
+| `cat *` | Read-only file content |
+| `head *`, `tail *` | Read-only file content |
+| `wc *` | Read-only counting |
+| `find *` | Read-only file search |
+| `grep *`, `rg *` | Read-only content search |
+| `which *`, `where *` | Read-only path lookup |
+| `echo *` | Output only |
+| `date`, `whoami`, `pwd` | Info only |
+| `file *` | Read-only type detection |
+| `diff *` | Read-only comparison |
+
+### Elixir/Phoenix Safe
+
+| Pattern | Rationale |
+|---------|-----------|
+| `mix compile *` | Build step, reversible |
+| `mix test *` | Read-only test execution |
+| `mix format --check-formatted *` | Read-only check |
+| `mix credo *` | Read-only analysis |
+| `mix hex.info *` | Read-only package info |
+| `mix hex.audit` | Read-only security check |
+| `mix deps.audit` | Read-only dependency check |
+| `mix xref *` | Read-only cross-reference |
+| `mix dialyzer *` | Read-only type check |
+| `mix phx.routes *` | Read-only route listing |
+| `elixir -e *` | Evaluation (treat as GREEN for simple expressions) |
+| `iex -S mix` | Interactive shell |
+
+### Git Read-Only
+
+| Pattern | Rationale |
+|---------|-----------|
+| `git status *` | Read-only |
+| `git log *` | Read-only |
+| `git diff *` | Read-only |
+| `git show *` | Read-only |
+| `git branch` (no -D/-d) | Read-only listing |
+| `git remote -v` | Read-only |
+| `git stash list` | Read-only |
+
+### Node/Frontend Safe
+
+| Pattern | Rationale |
+|---------|-----------|
+| `node -e *` | Evaluation |
+| `npx prettier --check *` | Read-only |
+| `npm ls *` | Read-only |
+| `npm outdated` | Read-only |
+
+## YELLOW — Write Operations (Recommend with Caution)
+
+Commands that modify local state but are generally recoverable.
+
+### Git Write Operations
+
+| Pattern | Note |
+|---------|------|
+| `git add *` | Stages files (reversible with reset) |
+| `git commit *` | Creates commit (reversible with reset) |
+| `git push` (no --force) | Publishes commits |
+| `git checkout *` | Switches branches, can discard changes |
+| `git switch *` | Switches branches |
+| `git stash *` | Saves/restores work |
+| `git merge *` | Merges branches |
+| `git rebase *` (no --force) | Rewrites history locally |
+| `git branch -d *` | Deletes merged branch |
+
+### Elixir Write Operations
+
+| Pattern | Note |
+|---------|------|
+| `mix format *` (without --check) | Modifies files (reversible via git) |
+| `mix deps.get` | Downloads dependencies |
+| `mix deps.compile *` | Compiles dependencies |
+| `mix ecto.migrate` | Runs migrations (has rollback) |
+| `mix ecto.rollback` | Rolls back migration |
+| `mix ecto.gen.migration *` | Creates migration file |
+| `mix phx.gen.* *` | Generates code files |
+| `mix ecto.setup` | Creates + migrates + seeds |
+
+### File Operations
+
+| Pattern | Note |
+|---------|------|
+| `mkdir *` | Creates directories |
+| `touch *` | Creates empty files |
+| `cp *` | Copies files |
+| `mv *` | Moves files (reversible if in git) |
+
+### Package Managers
+
+| Pattern | Note |
+|---------|------|
+| `npm install *` | Installs packages |
+| `npm run *` | Runs scripts |
+| `yarn *` | Package operations |
+| `hex.pm` commands | Package operations |
+
+## RED — Never Auto-Allow
+
+Commands that can cause irreversible damage, security risks, or
+affect systems beyond the local project.
+
+### Destructive Operations
+
+| Pattern | Risk |
+|---------|------|
+| `rm *` | File deletion (irreversible outside git) |
+| `rm -rf *` | Recursive deletion |
+| `rmdir *` | Directory deletion |
+| `mix ecto.reset` | Drops + recreates database |
+| `mix ecto.drop` | Drops database |
+| `git push --force *` | Overwrites remote history |
+| `git push -f *` | Overwrites remote history |
+| `git reset --hard *` | Discards uncommitted changes |
+| `git clean -f *` | Deletes untracked files |
+| `git branch -D *` | Force-deletes branch |
+
+### Privilege Escalation
+
+| Pattern | Risk |
+|---------|------|
+| `sudo *` | Elevated privileges |
+| `su *` | User switching |
+| `chmod 777 *` | World-writable permissions |
+| `chown *` | Ownership changes |
+
+### Network / External
+
+| Pattern | Risk |
+|---------|------|
+| `curl * \| sh` | Remote code execution |
+| `wget * \| sh` | Remote code execution |
+| `curl * \| bash` | Remote code execution |
+| `ssh *` | Remote access |
+| `scp *` | Remote file transfer |
+
+### Process Control
+
+| Pattern | Risk |
+|---------|------|
+| `kill *` | Process termination |
+| `killall *` | Mass process termination |
+| `pkill *` | Pattern-based process kill |
+
+### Container / Infrastructure
+
+| Pattern | Risk |
+|---------|------|
+| `docker rm *` | Container deletion |
+| `docker rmi *` | Image deletion |
+| `docker system prune *` | Mass cleanup |
+
+## Edge Cases
+
+### Compound Commands
+
+For piped or chained commands (`cmd1 | cmd2`, `cmd1 && cmd2`):
+
+- Classify EACH component separately
+- Final classification = highest risk component
+- `mix test | head` → GREEN (both GREEN)
+- `mix deps.get && rm -rf _build` → RED (rm is RED)
+
+### Commands with Redirects
+
+- `echo "text" > file.txt` → YELLOW (file write)
+- `cat file > /dev/null` → GREEN (null write is safe)
+
+### Environment Variables
+
+- `MIX_ENV=test mix test` → Same as `mix test` (GREEN)
+- `MIX_ENV=prod mix phx.server` → RED (production operations)
+- `DATABASE_URL=... mix ecto.*` → YELLOW (external DB connection)

--- a/plugins/elixir-phoenix/skills/permissions/references/settings-format.md
+++ b/plugins/elixir-phoenix/skills/permissions/references/settings-format.md
@@ -1,0 +1,169 @@
+# Claude Code Settings Permission Format
+
+How to correctly write permissions to Claude Code settings files.
+
+## Settings File Hierarchy
+
+Claude Code reads settings from multiple locations (in priority order):
+
+| File | Scope | Use Case |
+|------|-------|----------|
+| `~/.claude/settings.json` | Global (all projects) | Commands safe everywhere |
+| `.claude/settings.json` | Project (checked in) | Team-shared project permissions |
+| `.claude/settings.local.json` | Project (gitignored) | Personal project permissions |
+
+## Permission Format
+
+Permissions live under the `permissions` key with `allow` and `deny` arrays:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(mix test*)",
+      "Bash(mix compile*)",
+      "Bash(git status)"
+    ],
+    "deny": [
+      "Bash(rm -rf*)",
+      "Bash(sudo*)"
+    ]
+  }
+}
+```
+
+## Pattern Syntax
+
+Each permission entry follows `Tool(pattern)` format:
+
+| Pattern | Matches |
+|---------|---------|
+| `Bash(mix test*)` | Any bash command starting with `mix test` |
+| `Bash(git status)` | Exact match only |
+| `Bash(git diff*)` | `git diff`, `git diff --staged`, etc. |
+| `Bash(mix format*)` | `mix format`, `mix format --check-formatted`, etc. |
+
+### Rules
+
+- `*` is a glob wildcard (matches any characters)
+- Place `*` at the end to match commands with any arguments
+- Exact strings (no `*`) match only that exact command
+- Patterns are case-sensitive
+- `deny` takes priority over `allow`
+
+## Recommended Permission Sets
+
+### Minimal (Read-Only Developer)
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls*)",
+      "Bash(cat*)",
+      "Bash(grep*)",
+      "Bash(mix compile*)",
+      "Bash(mix test*)",
+      "Bash(git status)",
+      "Bash(git log*)",
+      "Bash(git diff*)"
+    ]
+  }
+}
+```
+
+### Standard Elixir Developer
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls*)",
+      "Bash(cat*)",
+      "Bash(grep*)",
+      "Bash(head*)",
+      "Bash(tail*)",
+      "Bash(wc*)",
+      "Bash(find*)",
+      "Bash(mix compile*)",
+      "Bash(mix test*)",
+      "Bash(mix format*)",
+      "Bash(mix credo*)",
+      "Bash(mix deps.get*)",
+      "Bash(mix ecto.migrate*)",
+      "Bash(mix ecto.rollback*)",
+      "Bash(mix ecto.gen.migration*)",
+      "Bash(mix phx.routes*)",
+      "Bash(mix hex.audit*)",
+      "Bash(mix deps.audit*)",
+      "Bash(mix xref*)",
+      "Bash(git status*)",
+      "Bash(git log*)",
+      "Bash(git diff*)",
+      "Bash(git show*)",
+      "Bash(git add*)",
+      "Bash(git commit*)",
+      "Bash(git push)",
+      "Bash(git branch)"
+    ]
+  }
+}
+```
+
+### Full-Trust Developer
+
+Adds git write operations and generators:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(mix *)",
+      "Bash(git *)",
+      "Bash(npm *)",
+      "Bash(ls*)",
+      "Bash(cat*)",
+      "Bash(grep*)",
+      "Bash(find*)",
+      "Bash(mkdir*)",
+      "Bash(cp*)"
+    ],
+    "deny": [
+      "Bash(mix ecto.reset*)",
+      "Bash(mix ecto.drop*)",
+      "Bash(git push --force*)",
+      "Bash(git push -f*)",
+      "Bash(git reset --hard*)",
+      "Bash(rm -rf*)",
+      "Bash(sudo*)"
+    ]
+  }
+}
+```
+
+## Merging Strategy
+
+When the permission analyzer writes to settings:
+
+1. **Read** current contents of the target settings file
+2. **Parse** existing `permissions.allow` array
+3. **Append** new entries (skip duplicates)
+4. **Never remove** existing entries
+5. **Write** merged result back
+
+```
+existing:  ["Bash(mix test*)", "Bash(git status)"]
+new:       ["Bash(mix test*)", "Bash(mix compile*)", "Bash(mix format*)"]
+merged:    ["Bash(mix test*)", "Bash(git status)", "Bash(mix compile*)", "Bash(mix format*)"]
+```
+
+## Project vs Global Placement
+
+| Command Type | Recommended Location |
+|-------------|---------------------|
+| Universal tools (`ls`, `grep`, `cat`) | `~/.claude/settings.json` (global) |
+| Elixir-specific (`mix test`, `mix compile`) | `.claude/settings.json` (project) |
+| Personal preferences | `.claude/settings.local.json` (local) |
+
+The analyzer should default to `.claude/settings.json` (project-level)
+for Elixir commands and suggest global placement for universal tools.


### PR DESCRIPTION
## Summary

Introduces a new `/phx:permissions` skill that analyzes recent Claude Code session history to identify frequently-approved Bash commands, classifies them by risk level (GREEN/YELLOW/RED), and recommends safe additions to `settings.json`. This addresses permission prompt fatigue by automating the discovery and configuration of safe, evidence-based permissions.

## Key Changes

- **New skill: `/phx:permissions`** (`plugins/elixir-phoenix/skills/permissions/SKILL.md`)
  - Scans session transcripts from the last N days (default: 14, configurable via `--days`)
  - Extracts and normalizes approved Bash commands
  - Classifies commands by risk using a comprehensive taxonomy
  - Presents recommendations in a table format before applying
  - Supports `--dry-run` flag to preview without modifying settings
  - Implements 4 Iron Laws: never auto-allow RED commands, evidence-based only, show before writing, preserve existing permissions

- **Risk classification reference** (`plugins/elixir-phoenix/skills/permissions/references/risk-classification.md`)
  - Comprehensive command taxonomy with GREEN (read-only), YELLOW (write operations), and RED (destructive/dangerous) categories
  - Specific rules for Elixir/Phoenix, Git, Node/npm, and system commands
  - Edge case handling for piped commands, redirects, and environment variables
  - Classification algorithm prioritizing deny-list over allow-list

- **Settings format reference** (`plugins/elixir-phoenix/skills/permissions/references/settings-format.md`)
  - Documents Claude Code's settings file hierarchy (`~/.claude/settings.json`, `.claude/settings.json`, `.claude/settings.local.json`)
  - Explains `Bash(pattern)` permission syntax with glob wildcard support
  - Provides three recommended permission sets (Minimal, Standard, Full-Trust)
  - Details the merge strategy for preserving existing permissions

- **Documentation updates**
  - Added `/phx:permissions` to the skill index in `CLAUDE.md`
  - Added unreleased changelog entry describing the feature

## Implementation Details

- Commands are normalized to base patterns (e.g., `mix test test/foo_test.exs` → `mix test*`) for grouping
- Approval frequency is tracked to help users understand which commands are most commonly used
- The skill defaults to project-level `.claude/settings.json` for Elixir-specific commands while suggesting global placement for universal tools
- Merge logic ensures existing user-configured permissions are never overwritten

https://claude.ai/code/session_01DdbSV5YyFxRS2bfEFKGhaS