### PR TITLE
Strengthen research cache reuse in planning orchestrator Phase 1c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **Planning orchestrator Phase 1c** — Expanded research cache reuse from 3 lines
+  to actionable implementation steps: discover candidates via glob, relevance
+  check via keyword grep, freshness gate (48h), agent skip mapping, and
+  scratchpad logging. Prevents redundant web/hex agent spawns when prior
+  `/phx:research` output exists
+
+### Fixed
+
+- **`setup-dirs.sh`** — Added `.claude/research/` to SessionStart directory
+  creation so the research output directory exists before `/phx:research` runs
+
 ## [2.5.0] - 2026-03-21
 
 ### Added

--- a/plugins/elixir-phoenix/agents/planning-orchestrator.md
+++ b/plugins/elixir-phoenix/agents/planning-orchestrator.md
@@ -60,9 +60,21 @@ Tidewave. Skip if unavailable — agents fall back to static analysis.
 
 ### Phase 1c: Research Cache Reuse
 
-Before spawning web/hex agents, check `.claude/research/` and
-`.claude/plans/*/research/` for matching research <48h old.
-If found, skip the agent and reuse cached findings.
+Before spawning web/hex agents, check for prior research that
+covers the planned feature's topics:
+
+1. **Discover**: Glob `.claude/research/*.md` and
+   `.claude/plans/*/research/*.md` for existing files
+2. **Relevance**: Grep candidates for keywords from the feature
+   description — 2+ keyword matches = relevant
+3. **Freshness**: Skip files older than 48h (`find -mtime -2`)
+4. **Apply** each relevant, fresh file:
+   - Include key findings in Phase 2 synthesis context
+   - **Skip** the corresponding agent:
+     `*-evaluation.md` → skip hex-library-researcher,
+     `research-*.md` → skip web-researcher for that topic
+   - Log: `REUSED: {filename} (skipped {agent})` in scratchpad
+5. **No match?** Proceed to Phase 2 normally
 
 ### Phase 2: Spawn Research Agents (Parallel)
 

--- a/plugins/elixir-phoenix/hooks/scripts/setup-dirs.sh
+++ b/plugins/elixir-phoenix/hooks/scripts/setup-dirs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SessionStart hook: Create core workflow directories (other dirs created by skills on demand)
-mkdir -p .claude/plans .claude/reviews .claude/solutions .claude/audit .claude/skill-metrics 2>/dev/null || true
+mkdir -p .claude/plans .claude/reviews .claude/solutions .claude/audit .claude/skill-metrics .claude/research 2>/dev/null || true
 
 # Create persistent plugin data directory (survives plugin updates)
 # ${CLAUDE_PLUGIN_DATA} is provided by Claude Code v2.1.78+


### PR DESCRIPTION
Expanded the thin 3-line Phase 1c into actionable implementation steps:
discover candidates via glob, relevance check via keyword grep, freshness
gate (48h), agent skip mapping with scratchpad logging. Also added
.claude/research/ to setup-dirs so the directory exists on session start.

https://claude.ai/code/session_01AWeNVKPi3vegNSajFi3cFh