### PR TITLE
feat: Add plan-review skill and correctness/adversarial reviewer agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   violations, scope creep, and feasibility issues in the plan before implementation
   begins. Auto-fixes are applied silently; strategic findings are reported at
   completion. Skipped for "just do it" discovery choice or plans with <= 2 units.
+- **`correctness-reviewer` agent** — Always-on code review agent that traces
+  execution paths to find logic errors, state management bugs, nil propagation,
+  race conditions, and cross-file invariant violations. Mentally executes code
+  with concrete values at boundaries. Catches bugs that pass tests because nobody
+  thought to test that input.
+- **`adversarial-reviewer` agent** — Conditional code review agent (>=50 changed
+  lines or high-risk domains) that constructs failure scenarios rather than checking
+  patterns. Hunts for assumption violations, composition failures across Phoenix
+  contexts, cascade failures in GenServer/Oban/PubSub chains, and abuse cases.
+  Specifically designed to catch cross-file state invariant bugs like counter drift.
+- **`/phx:review` now spawns correctness and adversarial reviewers** — Correctness
+  reviewer is always-on. Adversarial reviewer activates for large diffs or high-risk
+  domains. Both integrated into `/phx:full` review phase.
 
 ## [2.8.0] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the Elixir/Phoenix Claude Code plugin.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`/phx:plan-review` — Multi-persona plan review** — Review plan and requirements
+  documents through parallel persona agents before implementation. Dispatches
+  coherence, feasibility, and conditional reviewers (security, scope-guardian,
+  elixir-architecture) that check plans against Iron Laws and Phoenix conventions.
+  Auto-fixes clear issues, presents strategic questions for user judgment. Inspired
+  by Compound Engineering's document-review skill. Can be used standalone or runs
+  automatically as part of `/phx:full` in headless mode.
+- **`/phx:full` now includes plan review** — After the PLANNING phase and before
+  WORKING, `/phx:full` runs `/phx:plan-review mode:headless` to catch Iron Law
+  violations, scope creep, and feasibility issues in the plan before implementation
+  begins. Auto-fixes are applied silently; strategic findings are reported at
+  completion. Skipped for "just do it" discovery choice or plans with <= 2 units.
+
 ## [2.8.0] - 2026-04-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -669,6 +669,7 @@ When working on code, automatically consult relevant reference documentation bef
 | Understand a plan | `/phx:brief` |
 | Enhance existing plan | `/phx:plan --existing` |
 | Large feature (new domain) | `/phx:full` |
+| Review a plan before implementing | `/phx:plan-review` |
 | Review code | `/phx:review` |
 | Triage review findings | `/phx:triage` |
 | Capture solved problem | `/phx:compound` |
@@ -688,7 +689,10 @@ When working on code, automatically consult relevant reference documentation bef
 | Monitor skill effectiveness | `/skill-monitor` |
 | Validate plugin against docs | `/docs-check` |
 
-**Workflow Commands**: `/phx:brainstorm` (optional) -> `/phx:plan` -> `/phx:brief` (optional) -> `/phx:plan --existing` (optional) -> `/phx:work` -> `/phx:review` -> `/phx:triage` (optional) -> `/phx:compound`
+**Workflow Commands**:
+`/phx:brainstorm` (optional) -> `/phx:plan` -> `/phx:plan-review` (optional) ->
+`/phx:brief` (optional) -> `/phx:plan --existing` (optional) -> `/phx:work` ->
+`/phx:review` -> `/phx:triage` (optional) -> `/phx:compound`
 
 **Review → Follow-up Plan**: After `/phx:review`, if findings reveal scope gaps or missing coverage, use `/phx:plan .claude/plans/{slug}/reviews/{review}.md` to create a follow-up plan from review output.
 

--- a/plugins/elixir-phoenix/agents/adversarial-reviewer.md
+++ b/plugins/elixir-phoenix/agents/adversarial-reviewer.md
@@ -1,0 +1,110 @@
+---
+name: adversarial-reviewer
+description: Constructs failure scenarios to break implementations. Use when diff is large (>=50 lines) or touches auth, payments, data mutations, PubSub, or external APIs.
+tools: Read, Grep, Glob, Bash
+disallowedTools: Write, Edit, NotebookEdit
+permissionMode: bypassPermissions
+model: sonnet
+effort: high
+maxTurns: 20
+omitClaudeMd: true
+skills:
+  - ecto-patterns
+  - liveview-patterns
+  - oban
+  - security
+---
+
+# Adversarial Reviewer
+
+You are a chaos engineer who reads Elixir/Phoenix code by trying to
+break it. You construct specific scenarios that make it fail. You
+think in sequences: "if this happens, then that happens, which
+causes this to break." You don't evaluate — you attack.
+
+## Depth Calibration
+
+Estimate diff size and risk before reviewing.
+
+**Risk signals:** auth, payments, PubSub, GenServer state, Ecto.Multi,
+Oban workers, external APIs, LiveView assigns shared across processes.
+
+- **Quick** (under 50 lines, no risk): Assumption violation only. 2-3 findings max
+- **Standard** (50-199 lines, or minor risk): Assumption violation + composition failures + abuse cases
+- **Deep** (200+ lines, or strong risk): All four techniques including cascade construction
+
+## What You Hunt For
+
+### 1. Assumption Violation
+
+Construct scenarios where the code's assumptions break.
+
+- **Data shape** — code assumes Repo.get always returns a struct, a map always has a key, a list is non-empty, an association is preloaded. What if it doesn't?
+- **Timing** — code assumes a GenServer is alive, a PubSub message arrives before the next mount, an Oban job completes before the next one starts
+- **Ordering** — code assumes LiveView mount completes before handle_info fires, that handle_event runs after assign_async resolves, that migration ran before seed
+- **Value range** — code assumes IDs are positive, changeset is valid, enum values are exhaustive, timestamps are in UTC
+
+### 2. Composition Failures
+
+Trace interactions across boundaries where each part is correct alone but the combination fails.
+
+- **Cross-context invariants** — Context A increments a counter on condition X, Context B decrements on condition Y, but X and Y aren't complementary. The counter drifts
+- **PubSub contract mismatches** — Publisher sends `{:event, data}`, subscriber pattern-matches `{:event, id}`. Both compile, but the message is silently dropped
+- **LiveView + Context state divergence** — LiveView caches state in assigns, context mutates DB, assigns become stale. User sees old data, acts on it
+- **Ecto.Multi partial consistency** — Multi succeeds on DB writes but a side effect (PubSub broadcast, cache update) fails. DB is updated but dependents aren't notified
+
+### 3. Cascade Construction
+
+Build multi-step failure chains.
+
+- **GenServer bottleneck cascades** — Slow call blocks GenServer, callers queue up, timeouts cascade, supervisors restart, state is lost
+- **Oban retry storms** — Job fails, retries create duplicates because job isn't idempotent, each duplicate also fails, exponential growth
+- **LiveView reconnect cascades** — Server restart triggers mass reconnections, each mount hits the DB, DB overloads, more timeouts, more reconnections
+
+### 4. Abuse Cases
+
+Legitimate usage patterns that cause bad outcomes.
+
+- **Rapid event submission** — User clicks button rapidly, multiple handle_events fire, each creates a record. No dedup
+- **Concurrent LiveView mutations** — Two browser tabs, same user, same resource. Both read version 1, both submit updates, last write wins silently
+- **Stale assign actions** — User sees a list loaded 5 minutes ago, clicks delete on a record that another user already deleted. What happens?
+
+## Elixir-Specific Invariant Analysis
+
+**CRITICAL**: For every state mutation in the diff (counter increment/
+decrement, status change, flag toggle), trace ALL code paths that
+affect that state across ALL files. Ask:
+
+1. If path A increments, do ALL decrement paths have the complementary condition?
+2. Can any code path skip the mutation (early return, pattern match miss)?
+3. Is the state modified in multiple contexts? Are they coordinated?
+
+This is your highest-value technique for Elixir codebases where
+state is distributed across contexts, GenServers, and PubSub events.
+
+## Confidence Calibration
+
+- **High (0.80+)**: Complete scenario with traceable execution path
+- **Moderate (0.60-0.79)**: Scenario constructed but one step unconfirmed
+- **Low (<0.60)**: Suppress — pure speculation
+
+## What You Don't Flag
+
+- Individual logic bugs without cross-component impact (correctness-reviewer)
+- Known vulnerability patterns like atom injection (security-analyzer)
+- N+1 queries, missing indexes (elixir-reviewer)
+- Test coverage gaps (testing-reviewer)
+- Iron Law violations (iron-law-judge)
+- Code style (elixir-reviewer)
+
+Your territory is the space *between* these reviewers — problems
+that emerge from combinations, assumptions, and sequences.
+
+## Output
+
+Report findings as structured text with:
+
+- Scenario-oriented titles ("Cascade: Oban retry storm from non-idempotent worker")
+- Step-by-step failure path with file:line references
+- Severity: BLOCKER / WARNING / SUGGESTION
+- Confidence score

--- a/plugins/elixir-phoenix/agents/correctness-reviewer.md
+++ b/plugins/elixir-phoenix/agents/correctness-reviewer.md
@@ -1,0 +1,110 @@
+---
+name: correctness-reviewer
+description: Traces execution paths to find logic errors, state bugs, and intent-vs-implementation mismatches. Always-on for any code review.
+tools: Read, Grep, Glob, Bash
+disallowedTools: Write, Edit, NotebookEdit
+permissionMode: bypassPermissions
+model: sonnet
+effort: high
+maxTurns: 20
+omitClaudeMd: true
+skills:
+  - ecto-patterns
+  - liveview-patterns
+  - oban
+---
+
+# Correctness Reviewer
+
+You are a logic and behavioral correctness expert who reads
+Elixir/Phoenix code by mentally executing it — tracing inputs
+through pattern matches, tracking state across GenServer calls
+and LiveView lifecycle, and asking "what happens when this value
+is X?" You catch bugs that pass tests because nobody thought to
+test that input.
+
+## What You Hunt For
+
+### Off-by-one and Boundary Mistakes
+
+- Enum operations that skip the last element or include one too many
+- Pagination that misses the final page when total is exact multiple of page_size
+- Stream chunk boundaries that split a record across chunks
+- `Enum.at(list, length - 1)` vs `List.last(list)` edge cases
+- `Enum.slice` and `Enum.take` bounds with empty lists
+
+Trace the math with concrete values at the boundaries.
+
+### Nil and Error Propagation
+
+- `Repo.get` returns nil, caller pipes into a function expecting a struct
+- `with` chain where one clause returns `{:error, _}` but the else doesn't match it
+- `case` missing a clause — function returns unexpected value that propagates silently
+- Optional map access `map[:key]` returns nil, used in arithmetic or string interpolation
+- Changeset errors swallowed by returning `{:noreply, socket}` without flash or assign update
+
+### Race Conditions and Ordering
+
+- Two LiveView handle_events that modify the same assign — can they interleave?
+- PubSub broadcast received before LiveView finishes mount setup
+- `assign_async` result arrives after user navigates away — handle_async on dead socket
+- Oban worker and LiveView both update same DB record — last write wins
+- TOCTOU: `Repo.get` then `Repo.update` without optimistic locking
+
+### Incorrect State Transitions
+
+- LiveView assigns set in success path but not cleared on error path
+- Ecto changeset applies partial update — some fields change, related fields don't
+- Multi-step form wizard where going back doesn't restore previous state
+- PubSub-driven state that diverges from DB state after failed broadcast
+- Counter incremented in one code path, never decremented in the complementary path
+
+### Broken Error Propagation
+
+- `{:error, changeset}` caught and converted to `{:noreply, socket}` without showing errors
+- `Task.async` errors silently swallowed because `Task.await` is never called
+- `Oban.Worker.perform` returns `:ok` on failure (masks retry mechanism)
+- `with` clause returns `{:error, reason}` but else clause returns `{:error, :unknown}` — loses context
+- `try/rescue` that catches too broadly (`rescue e ->`) and re-raises wrong exception
+
+## Cross-File State Tracing
+
+**CRITICAL**: When the diff modifies state (assigns, DB records, counters,
+flags, statuses), trace that state across ALL files that read or write it.
+
+1. Grep for every reference to the modified field/column/assign
+2. For each reference, check: does this code path maintain the invariant?
+3. Build a state transition table: "from state A, event X → state B"
+4. Check: can any combination of events reach an invalid state?
+
+Example: If `unread_count` is incremented in `chat.ex` when a message
+arrives, check EVERY place that decrements it — `read_status_controller.ex`,
+`mark_all_read` in `notifications.ex`, Oban cleanup workers. Do all
+paths have complementary conditions?
+
+## Confidence Calibration
+
+- **High (0.80+)**: Full execution path traceable from input to bug.
+  "This input enters here, takes this branch, reaches this line,
+  and produces this wrong result"
+- **Moderate (0.60-0.79)**: Bug depends on conditions seen but
+  unconfirmed (e.g., whether a caller actually passes nil)
+- **Low (<0.60)**: Suppress — requires runtime conditions with no evidence
+
+## What You Don't Flag
+
+- Style preferences — naming, formatting, import ordering
+- Missing optimization — correct but slow is not your problem
+- Defensive coding suggestions — don't suggest nil checks for values
+  that can't be nil in the current code path
+- Security vulnerabilities — security-analyzer handles these
+- Iron Law violations — iron-law-judge handles these
+
+## Output
+
+Report findings as structured text with:
+
+- Bug-oriented titles ("Nil propagation: Repo.get result piped without guard")
+- Concrete execution trace with file:line references and specific values
+- Severity: BLOCKER / WARNING / SUGGESTION
+- Confidence score

--- a/plugins/elixir-phoenix/skills/full/SKILL.md
+++ b/plugins/elixir-phoenix/skills/full/SKILL.md
@@ -26,11 +26,11 @@ Cycles back automatically if review finds issues.
 │                       /phx:full {feature}                        │
 ├──────────────────────────────────────────────────────────────────┤
 │                                                                  │
-│  ┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐  │
-│  │Discover│→ │  Plan  │→ │  Work  │→ │ Verify │→ │ Review │→ │Compound│→Done│
-│  │ Assess │  │[Pn-Tm] │  │Execute │  │  Full  │  │4 Agents│  │Capture │     │
-│  │ Decide │  │ Phases │  │ Tasks  │  │  Loop  │  │Parallel│  │ Solve  │     │
-│  └───┬────┘  └────────┘  └────────┘  └───┬────┘  └────────┘  └────────┘     │
+│  ┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐  │
+│  │Discover│→ │  Plan  │→ │  Plan  │→ │  Work  │→ │ Verify │→ │ Review │→ │Compound│→Done│
+│  │ Assess │  │[Pn-Tm] │  │ Review │  │Execute │  │  Full  │  │4 Agents│  │Capture │     │
+│  │ Decide │  │ Phases │  │Personas│  │ Tasks  │  │  Loop  │  │Parallel│  │ Solve  │     │
+│  └───┬────┘  └────────┘  └────────┘  └────────┘  └───┬────┘  └────────┘  └────────┘     │
 │       │                            ↑      │    ↑              │         │
 │       ├── "just do it" ────────────┤      │    │              │         │
 │       ├── "plan it" ──┐            │      ↓    │              │         │
@@ -54,7 +54,7 @@ Cycles back automatically if review finds issues.
 ## State Machine
 
 ```
-STATES: INITIALIZING → DISCOVERING → PLANNING → WORKING →
+STATES: INITIALIZING → DISCOVERING → PLANNING → PLAN_REVIEWING → WORKING →
         VERIFYING → REVIEWING → COMPLETED → COMPOUNDING | BLOCKED
 ```
 
@@ -65,6 +65,7 @@ entry and `completed` on exit:
 ```
 TaskCreate({subject: "Discover & assess complexity", activeForm: "Discovering..."})
 TaskCreate({subject: "Plan feature", activeForm: "Planning..."})
+TaskCreate({subject: "Review plan", activeForm: "Reviewing plan..."})
 TaskCreate({subject: "Implement tasks", activeForm: "Working..."})
 TaskCreate({subject: "Verify implementation", activeForm: "Verifying..."})
 TaskCreate({subject: "Review with specialists", activeForm: "Reviewing..."})
@@ -89,7 +90,7 @@ Stop with INCOMPLETE status when limits exceeded. List remaining work and recomm
 ## Integration
 
 ```text
-/phx:full = /phx:plan → /phx:work → /phx:verify → /phx:review → (fix → /phx:verify) → /phx:compound
+/phx:full = /phx:plan → /phx:plan-review → /phx:work → /phx:verify → /phx:review → (fix → /phx:verify) → /phx:compound
 ```
 
 Use Ralph Wiggum Loop for fully autonomous execution:

--- a/plugins/elixir-phoenix/skills/full/SKILL.md
+++ b/plugins/elixir-phoenix/skills/full/SKILL.md
@@ -108,8 +108,8 @@ Use Ralph Wiggum Loop for fully autonomous execution:
 5. **Agent output is findings, not fixes** — Review agents report issues. Only the WORKING state makes code changes
 6. **Skip redundant review agents** — In REVIEWING phase: skip
    verification-runner (work phase already verified), skip iron-law-judge
-   if PostToolUse hooks verified all files. For <200 lines changed,
-   spawn only elixir-reviewer + security-analyzer (if auth files)
+   if PostToolUse hooks verified all files. Always spawn correctness-reviewer.
+   Spawn adversarial-reviewer for >=50 lines or high-risk domains
 7. **ZERO narration in autonomous mode** — This is a HARD rule, not
    a suggestion. NEVER write "Let me now...", "Now I need to...",
    "I'll now...", "Next, I will...", or any preamble before a tool

--- a/plugins/elixir-phoenix/skills/full/references/execution-steps.md
+++ b/plugins/elixir-phoenix/skills/full/references/execution-steps.md
@@ -108,14 +108,16 @@ WHILE unchecked tasks exist:
 
 Run `/phx:review`:
 
-Spawn 4 parallel review agents:
+Spawn parallel review agents (selection based on diff size and content):
 
-| Agent | Focus |
-|-------|-------|
-| elixir-reviewer | Idioms, patterns, code quality |
-| testing-reviewer | Test coverage, patterns |
-| security-analyzer | Security issues |
-| verification-runner | Full test suite |
+| Agent | Focus | When |
+|-------|-------|------|
+| elixir-reviewer | Idioms, patterns, code quality | Always |
+| correctness-reviewer | Logic errors, state bugs, cross-file invariants | Always |
+| adversarial-reviewer | Failure scenarios, composition failures, cascades | >=50 lines or high-risk |
+| testing-reviewer | Test coverage, patterns | Test files changed |
+| security-analyzer | Security issues | Auth files changed |
+| verification-runner | Full test suite | If not already run |
 
 **Exit condition**: Review complete.
 

--- a/plugins/elixir-phoenix/skills/full/references/execution-steps.md
+++ b/plugins/elixir-phoenix/skills/full/references/execution-steps.md
@@ -64,6 +64,29 @@ Run `/phx:plan {feature}` (with `--detail comprehensive` for "research it"):
 
 **Exit condition**: Plan file exists with checkboxes.
 
+## Step 3b: Plan Review Phase
+
+Run `/phx:plan-review mode:headless {plan-path}`:
+
+Dispatch parallel persona agents to review the plan document
+before implementation begins. Agents check for:
+
+- **Coherence**: Contradictions, terminology drift, wrong counts
+- **Feasibility**: Can this be built with current codebase patterns?
+- **Security** (conditional): Iron Laws 10-12 compliance in planned approach
+- **Scope** (conditional): Scope creep, unnecessary abstractions
+- **Elixir architecture** (conditional): Ecto/LiveView/OTP Iron Law compliance
+
+**Auto-fixes** (one clear correct fix) are applied to the plan
+silently. **Strategic findings** (need judgment) are logged but
+do not block the pipeline — they are reported at completion.
+
+**Skip conditions**: Skip if user chose "just do it" in discovery
+(no plan exists). Skip for plans with <= 2 implementation units
+(too small to benefit from review overhead).
+
+**Exit condition**: Plan reviewed, auto-fixes applied.
+
 ## Step 4: Work Phase (Loop)
 
 Run `/phx:work .claude/plans/{feature}/plan.md`:

--- a/plugins/elixir-phoenix/skills/help/SKILL.md
+++ b/plugins/elixir-phoenix/skills/help/SKILL.md
@@ -52,6 +52,7 @@ Map the user's situation to one of these categories:
 | **Resume work** | Existing plan with unchecked tasks | `/phx:work --continue` |
 | **Post-fix** | "that worked", solved a hard bug | `/phx:compound` |
 | **Full cycle** | Large feature, new domain area | `/phx:full` |
+| **Review a plan** | Check plan before implementing | `/phx:plan-review` |
 | **Project health** | "audit", "tech debt", "overall quality" | `/phx:audit`, `/phx:techdebt` |
 | **Deployment** | "deploy", "release", "production" | `/phx:verify` then deploy skill |
 | **Permissions** | "too many prompts", "allow", "permission fatigue" | `/phx:permissions` |

--- a/plugins/elixir-phoenix/skills/help/references/tool-catalog.md
+++ b/plugins/elixir-phoenix/skills/help/references/tool-catalog.md
@@ -75,6 +75,15 @@ These commands form a connected pipeline — each reads the previous phase's out
 - **Output**: All workflow artifacts
 - **Caution**: Best for well-defined features; complex ones benefit from manual phase control
 
+### `/phx:plan-review [path]` — Plan document review
+
+- **When**: After `/phx:plan`, before `/phx:work` — catch bad requirements before implementing
+- **Input**: Plan file path (or auto-detects most recent)
+- **Output**: Auto-fixed plan + findings for user judgment
+- **Agents**: coherence, feasibility, security (conditional), scope-guardian (conditional), elixir-architecture (conditional)
+- **Difference from /phx:review**: Reviews the *plan document*, not code
+- **Note**: Also runs automatically as part of `/phx:full` (headless mode)
+
 ## Standalone Commands
 
 ### `/phx:quick <description>` — Fast implementation
@@ -223,6 +232,7 @@ These commands form a connected pipeline — each reads the previous phase's out
 | Exploratory, may pivot | `/phx:plan` then decide |
 | Want control between phases | Manual: plan → work → review |
 | Large feature, new domain | `/phx:full` (handles complexity) |
+| Want plan reviewed before work | `/phx:plan` → `/phx:plan-review` → `/phx:work` |
 
 ### When to use `/phx:review` vs `/phx:verify`
 
@@ -250,10 +260,10 @@ These load automatically when you edit matching files:
 ## Workflow Cheat Sheet
 
 ```text
-New feature:     /phx:plan → /phx:work → /phx:review → /phx:compound
+New feature:     /phx:plan → /phx:plan-review → /phx:work → /phx:review → /phx:compound
 Quick fix:       /phx:quick
 Bug:             /phx:investigate
-Full auto:       /phx:full
+Full auto:       /phx:full (includes plan-review)
 Pre-PR:          /phx:verify → /phx:review
 Research:        /phx:research [topic]
 Evaluate lib:    /phx:research --library [name]

--- a/plugins/elixir-phoenix/skills/intro/references/tutorial-content.md
+++ b/plugins/elixir-phoenix/skills/intro/references/tutorial-content.md
@@ -80,7 +80,7 @@ Not everything needs the full cycle:
 | Command | When to Use | Time |
 |---------|------------|------|
 | `/phx:quick` | Bug fixes, small features (<100 lines) | ~2 min |
-| `/phx:full` | New features, autonomous plan-work-verify-review | ~10 min |
+| `/phx:full` | New features, autonomous plan-work-verify-review (includes plan review) | ~10 min |
 | `/phx:investigate` | Debugging — checks obvious things first | ~3 min |
 
 ### Decision Guide
@@ -313,11 +313,13 @@ The plugin works best when all layers are active: `/phx:init` for persistent rul
 | Command | Purpose |
 |---------|---------|
 | `/phx:quick <task>` | Fast implementation, skip ceremony |
-| `/phx:full <feature>` | Autonomous plan-work-review cycle |
+| `/phx:full <feature>` | Autonomous plan-work-review cycle (includes plan review) |
+| `/phx:plan-review` | Review plan docs before implementing |
 | `/phx:investigate <bug>` | Structured bug investigation |
 | `/phx:verify` | Run all quality checks |
 | `/phx:research <topic>` | Research with parallel workers, Tidewave-first |
 | `/phx:pr-review <PR#>` | Address PR review comments |
+| `/phx:plan-review` | Review plan docs before implementing |
 | `/phx:permissions` | Scan sessions, recommend safe Bash permissions |
 | `/phx:help [description]` | Interactive command advisor — helps pick the right command |
 

--- a/plugins/elixir-phoenix/skills/plan-review/SKILL.md
+++ b/plugins/elixir-phoenix/skills/plan-review/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: phx:plan-review
+description: Use after /phx:plan to review plan documents with parallel persona agents. Catches bad requirements, scope creep, and feasibility issues before implementation.
+effort: high
+argument-hint: "[mode:headless] [path/to/plan.md]"
+---
+
+# Plan Review — Multi-Persona Document Analysis
+
+Review plan and requirements documents through parallel persona
+agents. Catches issues before they become bad code.
+
+Inspired by Compound Engineering's document-review, adapted for
+Elixir/Phoenix with Iron Laws and BEAM-aware feasibility checks.
+
+## Usage
+
+```
+/phx:plan-review                                    # Review most recent plan
+/phx:plan-review .claude/plans/auth/plan.md          # Review specific plan
+/phx:plan-review mode:headless .claude/plans/auth/plan.md  # No interaction
+```
+
+## How This Differs from /phx:review
+
+| Aspect | `/phx:review` | `/phx:plan-review` |
+|--------|---------------|---------------------|
+| **Reviews** | Code (git diff) | Plans and requirements docs |
+| **Agents** | Elixir code specialists | Document analysis personas |
+| **Catches** | Bugs, anti-patterns, Iron Law violations | Scope creep, contradictions, infeasibility |
+| **When** | After implementation | After planning, before work |
+
+## Phase 1: Get and Classify Document
+
+If path provided, read it. Otherwise, find most recent in
+`.claude/plans/*/plan.md` via Glob.
+
+Classify as **requirements** (from brainstorm) or **plan** (from
+`/phx:plan`). Check for Elixir-specific content (Ecto schemas,
+LiveView, OTP, Oban) for agent selection.
+
+## Phase 2: Select and Dispatch Persona Agents
+
+**Always dispatch:**
+
+- **Coherence reviewer** — Contradictions, terminology drift,
+  section mismatches, wrong counts
+- **Feasibility reviewer** — Can this actually be built? Check
+  against codebase patterns, Phoenix conventions, OTP constraints
+
+**Conditionally dispatch based on plan content:**
+
+- **Security reviewer** — Auth, sessions, tokens, API endpoints,
+  user input handling. Checks against Security Iron Laws (10-12)
+- **Scope guardian** — Multiple priority tiers, >8 requirements,
+  scope boundary misalignment, unnecessary abstractions
+- **Elixir architecture reviewer** — Ecto schema design, context
+  boundaries, LiveView lifecycle, OTP supervision, Oban job design.
+  Checks plan against Ecto (4-6, 15, 17, 19) and LiveView (1-3, 18, 21) Iron Laws
+
+Announce which reviewers and why, then dispatch ALL in parallel
+using the Agent tool. Each agent receives the full document.
+
+**Agent prompt template:**
+
+```
+You are reviewing an Elixir/Phoenix {plan|requirements} document.
+Analyze for {persona focus}. Return findings as structured text:
+
+For each finding:
+- Section: [which section]
+- Issue: [what's wrong or missing]
+- Severity: P0 (must fix) | P1 (should fix) | P2 (consider)
+- Type: error (wrong) | omission (missing)
+- Fix: auto (one clear fix) | present (needs judgment)
+- Suggested fix: [if auto, the specific fix]
+- Evidence: [quote from document]
+
+Also check against these Iron Laws: {relevant laws}
+
+Document path: {path}
+Document content: {content}
+```
+
+## Phase 3: Synthesize Findings
+
+1. **Validate** — Drop findings missing required fields
+2. **Deduplicate** — Merge when same section + same issue across
+   agents. Keep highest severity and confidence
+3. **Resolve contradictions** — When agents disagree, present both
+   perspectives as a tradeoff for user decision
+4. **Route** — `auto` findings applied silently; `present` findings
+   shown to user for judgment
+
+## Phase 4: Apply and Present
+
+**Apply auto-fixes** to the plan document in a single pass.
+List what changed so user can verify.
+
+**Present remaining findings** grouped by severity (P0 -> P2),
+then by type (errors before omissions). Include coverage table
+showing which agents ran and finding counts.
+
+**Headless mode** (`mode:headless`): Skip all interaction. Apply
+auto-fixes, return structured text summary, exit immediately.
+
+## Phase 5: Next Action
+
+Ask the user:
+
+1. **Refine again** — Fix findings, re-review
+2. **Review complete** — Proceed to `/phx:work`
+
+After 2 refinement passes, recommend completion.
+
+## Iron Laws
+
+1. **Review is analysis, not rewriting** — Do not add new
+   requirements or sections the user didn't discuss
+2. **Auto-fix only when one clear fix** — If multiple valid
+   approaches exist, present to user
+3. **Elixir architecture agent checks Iron Laws** — Plan tasks
+   that would violate Iron Laws are P0 findings
+4. **NEVER skip feasibility** — Always check plan against actual
+   codebase patterns and Phoenix conventions
+
+## Integration
+
+```text
+/phx:plan → /phx:plan-review (YOU ARE HERE) → /phx:work → /phx:review → /phx:compound
+```
+
+## References
+
+- `${CLAUDE_SKILL_DIR}/references/review-output-template.md`

--- a/plugins/elixir-phoenix/skills/plan-review/references/review-output-template.md
+++ b/plugins/elixir-phoenix/skills/plan-review/references/review-output-template.md
@@ -1,0 +1,69 @@
+# Plan Review Output Template
+
+Use this format when presenting synthesized review findings.
+
+## Example
+
+```markdown
+## Plan Review Results
+
+**Document:** .claude/plans/user-auth/plan.md
+**Type:** plan
+**Reviewers:** coherence, feasibility, elixir-architecture, security
+- security -- plan adds auth flow with session tokens
+- elixir-architecture -- plan touches Ecto schemas and LiveView
+
+Applied 3 auto-fixes. 4 findings to consider (2 errors, 2 omissions).
+
+### Auto-fixes Applied
+
+- Fixed unit count from "4 units" to "5 units" to match listed units (coherence)
+- Added `mix compile --warnings-as-errors` to verification steps (feasibility)
+- Added preload requirement to Unit 3 query approach -- Iron Law 6 (elixir-architecture)
+
+### P0 -- Must Fix
+
+#### Errors
+
+| # | Section | Issue | Reviewer | Confidence |
+|---|---------|-------|----------|------------|
+| 1 | Unit 2 | Plan uses `String.to_atom(params["role"])` -- Iron Law 10 violation | elixir-architecture | 0.95 |
+
+### P1 -- Should Fix
+
+#### Errors
+
+| # | Section | Issue | Reviewer | Confidence |
+|---|---------|-------|----------|------------|
+| 2 | Scope | 6 of 8 units build admin UI; only 1 touches stated goal | scope-guardian | 0.82 |
+
+#### Omissions
+
+| # | Section | Issue | Reviewer | Confidence |
+|---|---------|-------|----------|------------|
+| 3 | Unit 4 | LiveView mount loads all records -- no streams for large lists (Iron Law 2) | elixir-architecture | 0.88 |
+
+### P2 -- Consider Fixing
+
+#### Omissions
+
+| # | Section | Issue | Reviewer | Confidence |
+|---|---------|-------|----------|------------|
+| 4 | Unit 3 | No mention of Oban job idempotency strategy (Iron Law 7) | elixir-architecture | 0.72 |
+
+### Coverage
+
+| Persona | Status | Findings | Auto | Present |
+|---------|--------|----------|------|---------|
+| coherence | completed | 2 | 1 | 1 |
+| feasibility | completed | 2 | 1 | 1 |
+| elixir-architecture | completed | 3 | 1 | 2 |
+| security | completed | 2 | 0 | 2 |
+```
+
+## Section Rules
+
+- **Summary line**: "Applied N auto-fixes. K findings to consider (X errors, Y omissions)."
+- **Auto-fixes Applied**: List all auto-applied fixes with detail. Omit if none.
+- **P0-P2 sections**: Only include sections with findings. Separate Errors/Omissions.
+- **Coverage**: Always include. Findings = Auto + Present.

--- a/plugins/elixir-phoenix/skills/review/SKILL.md
+++ b/plugins/elixir-phoenix/skills/review/SKILL.md
@@ -66,6 +66,8 @@ based on the diff, then spawn selected agents in ONE message (parallel):**
 | Agent | subagent_type | When to spawn |
 |-------|---------------|---------------|
 | Elixir Reviewer | `elixir-phoenix:elixir-reviewer` | **Always** |
+| Correctness Reviewer | `elixir-phoenix:correctness-reviewer` | **Always** — traces execution paths for logic errors, state bugs, cross-file invariant violations |
+| Adversarial Reviewer | `elixir-phoenix:adversarial-reviewer` | >=50 lines changed OR touches auth/payments/PubSub/GenServer state/external APIs. Constructs failure scenarios |
 | Iron Law Judge | `elixir-phoenix:iron-law-judge` | Only if >200 lines changed AND auth/LiveView/Oban files in diff. **Skip** if PostToolUse hooks already verified all files (hooks check Iron Laws on every Edit/Write) |
 | Verification Runner | `elixir-phoenix:verification-runner` | Only if `mix test` has NOT been run in this session. **Skip** if `/phx:work` just passed all verification tiers |
 | Security Analyzer | `elixir-phoenix:security-analyzer` | Auth/session/password/token files changed |
@@ -73,9 +75,9 @@ based on the diff, then spawn selected agents in ONE message (parallel):**
 | Oban Specialist | `elixir-phoenix:oban-specialist` | Worker files changed (*_worker.ex) |
 | Deploy Validator | `elixir-phoenix:deployment-validator` | Dockerfile/fly.toml/runtime.exs changed |
 
-**Agent count**: Min 1, max 5. For <200 lines changed: spawn only
-elixir-reviewer + security-analyzer (if auth files). Log selection
-rationale in review output.
+**Agent count**: Min 1, max 7. For <50 lines changed: spawn only
+elixir-reviewer + correctness-reviewer. Log selection rationale in
+review output.
 Spawn with `mode: "bypassPermissions"` and `run_in_background: true`.
 
 **For focused reviews — spawn the specified agent only:**
@@ -87,6 +89,8 @@ Spawn with `mode: "bypassPermissions"` and `run_in_background: true`.
 | `oban` | `elixir-phoenix:oban-specialist` |
 | `deploy` | `elixir-phoenix:deployment-validator` |
 | `iron-laws` | `elixir-phoenix:iron-law-judge` |
+| `correctness` | `elixir-phoenix:correctness-reviewer` |
+| `adversarial` | `elixir-phoenix:adversarial-reviewer` |
 
 Zero agents spawned = skill failure.
 


### PR DESCRIPTION
## Summary

- Adds `/phx:plan-review` — multi-persona plan document review with parallel agents (coherence, feasibility, security, scope-guardian, elixir-architecture) that catch bad requirements, Iron Law violations, and scope creep before implementation
- Adds `correctness-reviewer` agent — always-on, traces execution paths to find logic errors, nil propagation, race conditions, and cross-file state invariant violations
- Adds `adversarial-reviewer` agent — conditional (>=50 lines or high-risk), constructs failure scenarios for assumption violations, composition failures, and cascades
- Integrates plan-review into `/phx:full` as Step 3b (headless mode between PLANNING and WORKING)
- Wires both reviewer agents into `/phx:review` and `/phx:full` review phase

## Motivation

The existing Elixir review agents (elixir-reviewer, security-analyzer, testing-reviewer) excel at structural pattern matching but miss bugs that require cross-file semantic reasoning — like counter increment/decrement invariant violations across contexts. CE's adversarial and correctness reviewers catch these by constructing failure scenarios and tracing state transitions across files. These Elixir-adapted versions bring that capability with BEAM-aware patterns (GenServer state, PubSub contracts, Ecto.Multi consistency, LiveView assign divergence).

Similarly, no existing skill reviews plan documents before implementation. `/phx:plan-review` catches bad plans before they become bad code.

## Test plan

- [ ] Run `/phx:plan-review .claude/plans/*/plan.md` and verify persona agents dispatch and findings are presented
- [ ] Run `/phx:review` on a diff >=50 lines and verify adversarial-reviewer spawns alongside correctness-reviewer
- [ ] Run `/phx:review correctness` for focused correctness review
- [ ] Run `/phx:full` and verify plan-review runs between planning and working phases
- [ ] `make eval` passes (5 skills scored, all perfect, avg 1.000)
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)