### PR TITLE
fix(skills): quote argument-hint YAML strings starting with '['

### DIFF
--- a/plugins/elixir-phoenix/skills/audit/SKILL.md
+++ b/plugins/elixir-phoenix/skills/audit/SKILL.md
@@ -2,7 +2,7 @@
 name: phx:audit
 description: Project health audit and health check — architecture, performance, tests, dependencies, code quality. Use when assessing overall project health, before releases, or after refactors.
 effort: high
-argument-hint: [--quick|--full|--focus=area|--since=commit]
+argument-hint: "[--quick|--full|--focus=area|--since=commit]"
 ---
 
 # Project Health Audit

--- a/plugins/elixir-phoenix/skills/boundaries/SKILL.md
+++ b/plugins/elixir-phoenix/skills/boundaries/SKILL.md
@@ -2,7 +2,7 @@
 name: phx:boundaries
 description: Analyze Phoenix context boundaries and module coupling via mix xref. Use when checking cross-context calls, validating dependencies, before splitting modules, or reviewing architecture.
 effort: medium
-argument-hint: [--assess|--fix]
+argument-hint: "[--assess|--fix]"
 allowed-tools: Read, Grep, Glob, Bash
 ---
 

--- a/plugins/elixir-phoenix/skills/brief/SKILL.md
+++ b/plugins/elixir-phoenix/skills/brief/SKILL.md
@@ -2,7 +2,7 @@
 name: phx:brief
 description: Interactive briefing of a plan file — explains reasoning, schema decisions, component choices. Use when developers need to understand a plan before approving.
 effort: low
-argument-hint: [path to plan file]
+argument-hint: "[path to plan file]"
 ---
 
 # Plan Briefing

--- a/plugins/elixir-phoenix/skills/compound/SKILL.md
+++ b/plugins/elixir-phoenix/skills/compound/SKILL.md
@@ -2,7 +2,7 @@
 name: phx:compound
 description: Capture solved problems as searchable solution docs. Use after fixing bugs, when "that worked", or after successful /phx:review or /phx:investigate.
 effort: low
-argument-hint: [description of what was fixed]
+argument-hint: "[description of what was fixed]"
 ---
 
 # Compound — Capture Solutions as Knowledge

--- a/plugins/elixir-phoenix/skills/document/SKILL.md
+++ b/plugins/elixir-phoenix/skills/document/SKILL.md
@@ -2,7 +2,7 @@
 name: phx:document
 description: Generate @moduledoc and @doc strings for Elixir modules, contexts, and schemas. Use when explicitly asked to write @doc/@moduledoc — NOT for README or external docs.
 effort: low
-argument-hint: [plan-file OR feature-name]
+argument-hint: "[plan-file OR feature-name]"
 ---
 
 # Document

--- a/plugins/elixir-phoenix/skills/init/SKILL.md
+++ b/plugins/elixir-phoenix/skills/init/SKILL.md
@@ -2,7 +2,7 @@
 name: phx:init
 description: Initialize plugin in a project — install Iron Laws, auto-activation rules, and reference auto-loading into CLAUDE.md. Use when setting up or updating the plugin.
 effort: low
-argument-hint: [--update]
+argument-hint: "[--update]"
 ---
 
 # Plugin Initialization

--- a/plugins/elixir-phoenix/skills/intro/SKILL.md
+++ b/plugins/elixir-phoenix/skills/intro/SKILL.md
@@ -2,7 +2,7 @@
 name: phx:intro
 description: Walk through the Elixir/Phoenix plugin commands, workflow, and features in 6 interactive sections. Use when a new user wants to learn what the plugin offers or needs a refresher on available commands.
 effort: low
-argument-hint: [--section N]
+argument-hint: "[--section N]"
 ---
 
 # Plugin Introduction Tutorial

--- a/plugins/elixir-phoenix/skills/review/SKILL.md
+++ b/plugins/elixir-phoenix/skills/review/SKILL.md
@@ -2,7 +2,7 @@
 name: phx:review
 description: Review code with parallel agents — tests, security, Ecto, LiveView, Oban. Use after implementation to catch bugs and anti-patterns before committing.
 effort: high
-argument-hint: [test|security|oban|deploy|iron-laws|all]
+argument-hint: "[test|security|oban|deploy|iron-laws|all]"
 ---
 
 # Review Elixir/Phoenix Code

--- a/plugins/elixir-phoenix/skills/triage/SKILL.md
+++ b/plugins/elixir-phoenix/skills/triage/SKILL.md
@@ -2,7 +2,7 @@
 name: phx:triage
 description: Triage review findings interactively — approve, skip, or prioritize each issue. Use after /phx:review to filter findings before fixing.
 effort: low
-argument-hint: [path to review file]
+argument-hint: "[path to review file]"
 ---
 
 # Triage — Interactive Review Resolution


### PR DESCRIPTION
## Summary

Nine `SKILL.md` files in `plugins/elixir-phoenix/skills/` declare their `argument-hint` frontmatter value as an unquoted `[...]`, e.g.:

```yaml
argument-hint: [--quick|--full|--focus=area|--since=commit]
```

In YAML, an unquoted value that begins with `[` is a **flow sequence** (array), not a scalar string. Copilot CLI **1.0.65** tightened its frontmatter validator to require `argument-hint` to be a string, and now hard-errors on the array form, so these nine skills fail to load in that runtime.

Claude Code accepts both today (it stringifies frontmatter values loosely), but the same latent ambiguity has been observed to trip it (see [anthropics/claude-code#22161](https://github.com/anthropics/claude-code/issues/22161) for a parallel case). Quoting is the safer, forwards-compatible form for both runtimes.

## The YAML rule

- `argument-hint: [X]`  → parses as a **list** `['X']`. Bad.
- `argument-hint: "[X]"` → parses as a **string** `'[X]'`. Good.
- `argument-hint: <X>`  → parses as a string (no leading YAML metachar). Fine as-is.

If the string contains a double-quote, single-quote the outer wrapper; none of these nine did, so plain double quotes suffice.

## Fix

Wrap each hint in double quotes:

```diff
-argument-hint: [--quick|--full|--focus=area|--since=commit]
+argument-hint: "[--quick|--full|--focus=area|--since=commit]"
```

Affected files (all under `plugins/elixir-phoenix/skills/`):

- `audit/SKILL.md`
- `boundaries/SKILL.md`
- `brief/SKILL.md`
- `compound/SKILL.md`
- `document/SKILL.md`
- `init/SKILL.md`
- `intro/SKILL.md`
- `review/SKILL.md`
- `triage/SKILL.md`

Two other skills use `argument-hint: <...>` (`assigns-audit`, `challenge`) and `argument-hint: ecto | liveview | pr` — both start with non-metacharacters and parse as strings already, so they are unchanged. Skills that already wrap in double quotes (many of them, plus every skill in `catchup/` and `.claude/`) are unchanged.

No source-of-truth values are changed — only the YAML representation.

## Test plan

- [x] `rg '^argument-hint: \[' plugins/` returns no matches after the fix.
- [x] For each of the 9 files, `python3 -c 'import yaml, sys; d = yaml.safe_load(open(sys.argv[1]).read().split("---")[1]); assert isinstance(d["argument-hint"], str)' <file>` succeeds.
- [x] `npx markdownlint` (repo config) passes on all 9 files.
- [x] `make eval` (repo pre-commit gate) passes: `9 skills scored | 4 perfect | avg 0.979` — all above the 0.95 threshold.
- [x] Pre-commit hook (markdownlint + `make eval`) runs green on the commit.
- [ ] Optional maintainer check: install this branch into Copilot CLI 1.0.65 and confirm the nine skills now load. (I don't have Copilot CLI locally to verify end-to-end there.)

## Notes

- One-line change per file, indentation preserved.
- No changes to skill behavior, documentation, or references.
- Commit style follows the existing `fix(scope): message` convention visible in `git log`.