### PR TITLE
docs(ecto): Repo.transaction/1 changeset error handling (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`ecto-patterns`: `Repo.transaction/1` changeset error handling** — new
+  reference section (and an anti-pattern row in the auto-loaded SKILL.md) on the
+  bare-match footgun inside `Repo.transaction(fn -> ... end)`: `{:ok, _} =
+  Repo.update(cs)` raises `MatchError` on an invalid changeset, which rolls back
+  and **re-raises** (crashing the caller, e.g. a `500`) — it does *not* return
+  `{:error, %MatchError{}}`. Documents the explicit `case` + `Repo.rollback/1`
+  fix (single step) and the `with ... else` fix (multi-step), and points to
+  `Repo.transact/1` / `Ecto.Multi` as the footgun-free forms. Verified
+  empirically on Ecto 3.14. Thanks to @ndrean for the proposal (#76).
+
 ### Changed
 
 ### Fixed

--- a/plugins/elixir-phoenix/skills/ecto-patterns/SKILL.md
+++ b/plugins/elixir-phoenix/skills/ecto-patterns/SKILL.md
@@ -78,6 +78,7 @@ end
 | `Repo.all(User) \|> Enum.filter(& &1.active)` | `from(u in User, where: u.active)` |
 | Preloading in loops | `Repo.preload(posts, :comments)` |
 | `Repo.get!(User, user_id)` with user input | `Repo.get(User, id)` + handle nil |
+| `{:ok, _} = Repo.update(cs)` inside `Repo.transaction` | `case`/`with` + `Repo.rollback(cs)` (see transactions.md) |
 
 ## References
 

--- a/plugins/elixir-phoenix/skills/ecto-patterns/references/transactions.md
+++ b/plugins/elixir-phoenix/skills/ecto-patterns/references/transactions.md
@@ -11,6 +11,51 @@ Repo.transact(fn ->
 end)
 ```
 
+## Repo.transaction/1: changeset error handling
+
+Inside the callback form `Repo.transaction(fn -> ... end)`, a bare `{:ok, _} =`
+match on a write is a footgun. When the write returns `{:error, changeset}`, the
+match raises `MatchError`; the transaction rolls back and **re-raises** it, so the
+caller crashes (a `500` in a request) and the changeset's validation errors are
+lost. It does *not* return `{:error, %MatchError{}}` — nothing catches it for you.
+
+```elixir
+# BAD — invalid changeset raises MatchError, which propagates and crashes the caller
+Repo.transaction(fn ->
+  {:ok, updated} = Repo.update(changeset)
+  updated
+end)
+
+# GOOD — explicit case + Repo.rollback/1 preserves the changeset
+Repo.transaction(fn ->
+  case Repo.update(changeset) do
+    {:ok, updated} -> updated
+    {:error, changeset} -> Repo.rollback(changeset)
+  end
+end)
+# => {:error, %Ecto.Changeset{}} — caller gets actionable validation errors
+```
+
+The same applies to `Repo.insert/1` and `Repo.delete/1`. For multiple steps, use
+`with ... else` and roll back on the error path:
+
+```elixir
+Repo.transaction(fn ->
+  with {:ok, user}    <- Repo.insert(user_changeset),
+       {:ok, profile} <- Repo.insert(profile_changeset(user)) do
+    profile
+  else
+    {:error, changeset} -> Repo.rollback(changeset)
+  end
+end)
+```
+
+Prefer `Repo.transact/1` (above) or `Ecto.Multi` (below) when you can — both
+surface `{:error, ...}` on failure without a manual `Repo.rollback/1`, steering
+you away from the bare match. This footgun is specific to the classic
+`Repo.transaction/1` callback form. (Ties to Iron Laws #18 and #24 — check
+changeset errors, and match `{:error, %Ecto.Changeset{}}` explicitly.)
+
 ## Ecto.Multi (Complex operations, testing)
 
 ```elixir


### PR DESCRIPTION
Closes #76.

Implements @ndrean's proposal: document that a bare `{:ok, _} =` match on a
write inside `Repo.transaction(fn -> ... end)` is a footgun that loses the
changeset's validation errors.

## What changed

- **`skills/ecto-patterns/references/transactions.md`** — new
  `## Repo.transaction/1: changeset error handling` section (placed right after
  `Repo.transact`, as requested in the issue) with BAD / GOOD examples for the
  single-step (`case` + `Repo.rollback/1`) and multi-step (`with ... else`) forms.
- **`skills/ecto-patterns/SKILL.md`** — one anti-pattern-table row so the footgun
  is visible in the auto-loaded skill, not just the reference (references aren't
  reliably read by subagents).
- **`CHANGELOG.md`** — entry under `[Unreleased] → Added`.

## One correction to the proposal

The issue says the failure "returns `{:error, %MatchError{}}`". I verified
empirically on **Ecto 3.14.1 / ecto_sql 3.14.0** (minimal SQLite repo) that it
actually **raises `MatchError`**, which the transaction rolls back and
**re-raises** — so the caller crashes (a `500` in a request), it does not get a
`{:error, ...}` tuple back. That's an even stronger reason for the explicit
`case`/`with` + `Repo.rollback/1` pattern, so the docs reflect the measured
behavior.

```
=== 1. BAD: bare {:ok, _} = match on invalid changeset ===
outcome: {:RAISED, MatchError}
=== 2. GOOD: explicit case + Repo.rollback/1 ===
outcome: {:error, %Ecto.Changeset{}}  errors=[name: {"should be at least %{count} character(s)", ...}]
```

The guidance also matches the idiom used across our own codebases (single-step
`case` + rollback; multi-step `with ... else` + rollback) and ties into the
plugin's existing Iron Laws #18 (check changeset errors) and #24 (match
`{:error, %Ecto.Changeset{}}` explicitly).

## Checks

- `make eval` — `ecto-patterns` scored **1.000** (perfect), trigger accuracy ≥ 75%
- `npx markdownlint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)