### PR TITLE
refactor(port): extract pure skill transformation primitives

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,10 +57,10 @@ jobs:
         run: pip install pyyaml ruff pip-audit
 
       - name: Ruff lint (Python)
-        run: ruff check lab/ --select E,F,W --ignore E501,E402
+        run: ruff check lab/ scripts/ --select E,F,W --ignore E501,E402
 
       - name: Ruff format check
-        run: ruff format --check lab/ || true
+        run: ruff format --check lab/ scripts/ || true
 
       - name: Pip audit (security)
         run: pip-audit -r requirements.txt || true
@@ -117,7 +117,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Run pytest
-        run: python3 -m pytest lab/eval/tests/ -v --tb=short
+        run: python3 -m pytest lab/eval/tests/ scripts/tests/ -v --tb=short
 
   eval:
     name: Skill & Agent Eval

--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,11 @@ eval-agents: ## Score all agents only
 
 # --- Test ---
 
-test: ## Run pytest (75 tests for eval framework)
-	@python3 -m pytest lab/eval/tests/ -v --tb=short
+test: ## Run pytest for eval framework and port primitives
+	@python3 -m pytest lab/eval/tests/ scripts/tests/ -v --tb=short
 
 test-quick: ## Run pytest (no verbose, fast)
-	@python3 -m pytest lab/eval/tests/ -q
+	@python3 -m pytest lab/eval/tests/ scripts/tests/ -q
 
 # --- Validate ---
 
@@ -79,6 +79,6 @@ ci: lint test validate eval-all security ## Full CI: lint + test + validate + ev
 # --- Clean ---
 
 clean: ## Remove Python cache files
-	@find lab/ -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
-	@find lab/ -name "*.pyc" -delete 2>/dev/null || true
+	@find lab/ scripts/ -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+	@find lab/ scripts/ -name "*.pyc" -delete 2>/dev/null || true
 	@echo "Cleaned"

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository automation scripts."""

--- a/scripts/port_lib/__init__.py
+++ b/scripts/port_lib/__init__.py
@@ -1,0 +1,9 @@
+"""Shared paths and pure transforms for generated plugin targets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT: Path = Path(__file__).resolve().parents[2]
+SOURCE_PLUGIN_DIR: Path = REPO_ROOT / "plugins" / "elixir-phoenix"
+TARGETS_DIR: Path = REPO_ROOT / "targets"

--- a/scripts/port_lib/frontmatter.py
+++ b/scripts/port_lib/frontmatter.py
@@ -1,0 +1,64 @@
+"""Read and write YAML frontmatter without changing Markdown bodies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+DELIMITER = "---"
+
+
+@dataclass
+class Frontmatter:
+    data: dict
+    body: str
+
+    def dump(self) -> str:
+        """Serialize frontmatter and body back to a complete file."""
+        if not self.data:
+            return self.body
+
+        head = yaml.safe_dump(
+            self.data,
+            sort_keys=False,
+            allow_unicode=True,
+        ).rstrip()
+        return f"{DELIMITER}\n{head}\n{DELIMITER}\n{self.body}"
+
+
+def parse(text: str, source: str | None = None) -> Frontmatter:
+    """Split Markdown into a frontmatter mapping and unchanged body."""
+    if not text.startswith(DELIMITER):
+        return Frontmatter(data={}, body=text)
+
+    lines = text.splitlines(keepends=True)
+    end_idx = None
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == DELIMITER:
+            end_idx = index
+            break
+
+    prefix = f"{source}: " if source else ""
+    if end_idx is None:
+        raise ValueError(f"{prefix}malformed frontmatter — opener `---` without closer")
+
+    yaml_block = "".join(lines[1:end_idx])
+    body = "".join(lines[end_idx + 1 :])
+    data = yaml.safe_load(yaml_block) or {}
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"{prefix}frontmatter must be a mapping, got {type(data).__name__}"
+        )
+
+    return Frontmatter(data=data, body=body)
+
+
+def parse_file(path: str | Path) -> Frontmatter:
+    file_path = Path(path)
+    return parse(file_path.read_text(encoding="utf-8"), source=str(file_path))
+
+
+def write_file(path: str | Path, frontmatter: Frontmatter) -> None:
+    Path(path).write_text(frontmatter.dump(), encoding="utf-8")

--- a/scripts/port_lib/frontmatter.py
+++ b/scripts/port_lib/frontmatter.py
@@ -6,8 +6,40 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
+from yaml.constructor import ConstructorError
+from yaml.nodes import MappingNode
+from yaml.resolver import BaseResolver
 
 DELIMITER = "---"
+
+
+class _UniqueKeyLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects duplicate mapping keys."""
+
+
+def _construct_unique_mapping(
+    loader: _UniqueKeyLoader,
+    node: MappingNode,
+    deep: bool = False,
+) -> dict:
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueKeyLoader.add_constructor(
+    BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
 
 
 @dataclass
@@ -30,13 +62,13 @@ class Frontmatter:
 
 def parse(text: str, source: str | None = None) -> Frontmatter:
     """Split Markdown into a frontmatter mapping and unchanged body."""
-    if not text.startswith(DELIMITER):
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].rstrip("\r\n") != DELIMITER:
         return Frontmatter(data={}, body=text)
 
-    lines = text.splitlines(keepends=True)
     end_idx = None
     for index, line in enumerate(lines[1:], start=1):
-        if line.strip() == DELIMITER:
+        if line.rstrip("\r\n") == DELIMITER:
             end_idx = index
             break
 
@@ -46,8 +78,13 @@ def parse(text: str, source: str | None = None) -> Frontmatter:
 
     yaml_block = "".join(lines[1:end_idx])
     body = "".join(lines[end_idx + 1 :])
-    data = yaml.safe_load(yaml_block) or {}
-    if not isinstance(data, dict):
+    try:
+        data = yaml.load(yaml_block, Loader=_UniqueKeyLoader)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{prefix}invalid YAML frontmatter — {exc}") from exc
+    if data is None:
+        data = {}
+    elif not isinstance(data, dict):
         raise ValueError(
             f"{prefix}frontmatter must be a mapping, got {type(data).__name__}"
         )

--- a/scripts/port_lib/skill_transforms.py
+++ b/scripts/port_lib/skill_transforms.py
@@ -1,0 +1,130 @@
+"""Pure source-to-target transforms for Agent Skills."""
+
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+from typing import Iterable
+
+AGENTSKILLS_FIELDS = {"name", "description", "license"}
+
+CLAUDE_EXTENSION_FIELDS = {
+    "effort",
+    "allowed-tools",
+    "disallowed-tools",
+    "model",
+    "memory",
+    "skills",
+    "permissionMode",
+    "omitClaudeMd",
+}
+
+
+def normalize_skill_name(name: str) -> str:
+    """Normalize namespaced skill names for targets that disallow colons."""
+    if not name:
+        return name
+    return name.replace(":", "-")
+
+
+def transform_frontmatter(data: dict, target: str) -> dict:
+    """Preserve Claude frontmatter or project it to Agent Skills fields."""
+    if target == "claude":
+        return dict(data)
+
+    if target not in ("codex", "pi", "opencode"):
+        raise ValueError(f"Unknown target: {target}")
+
+    output: dict = {}
+    metadata: dict = {}
+
+    for key, value in data.items():
+        if key == "name":
+            output["name"] = normalize_skill_name(value)
+        elif key in AGENTSKILLS_FIELDS:
+            output[key] = value
+        else:
+            metadata[key] = value
+
+    if isinstance(output.get("description"), str):
+        output["description"] = rewrite_slash_commands(
+            output["description"],
+            target,
+        )
+
+    if metadata:
+        output["metadata"] = metadata
+    return output
+
+
+_CLAUDE_REF_RE = re.compile(r"\$\{CLAUDE_SKILL_DIR\}/references/([\w./-]+)")
+_SLASH_CMD_RE = re.compile(r"/(phx|lv|ecto):([a-z][a-z0-9-]*)")
+
+
+def rewrite_reference_paths(body: str, target: str) -> str:
+    """Rewrite Claude skill reference paths to skill-relative paths."""
+    if target == "claude":
+        return body
+    return _CLAUDE_REF_RE.sub(r"references/\1", body)
+
+
+def port_references(
+    refs_src: str | Path,
+    refs_dst: str | Path,
+    target: str,
+) -> None:
+    """Copy references, transforming Markdown and preserving other files."""
+    source = Path(refs_src)
+    destination = Path(refs_dst)
+
+    if destination.exists():
+        shutil.rmtree(destination)
+    destination.mkdir(parents=True)
+
+    for src in source.rglob("*"):
+        if src.is_dir():
+            continue
+
+        output = destination / src.relative_to(source)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        if src.suffix == ".md":
+            text = src.read_text(encoding="utf-8")
+            text = rewrite_reference_paths(text, target)
+            text = rewrite_slash_commands(text, target)
+            output.write_text(text, encoding="utf-8")
+        else:
+            output.write_bytes(src.read_bytes())
+
+
+def rewrite_slash_commands(body: str, target: str) -> str:
+    """Rewrite Claude namespaced command references for a target."""
+    if target == "claude":
+        return body
+    if target == "codex":
+        return _SLASH_CMD_RE.sub(r"\1-\2", body)
+    if target in ("pi", "opencode"):
+        return _SLASH_CMD_RE.sub(r"/\1-\2", body)
+    raise ValueError(f"Unknown target: {target}")
+
+
+_IRON_LAW_HEADER = "## Iron Laws (Inlined)"
+
+
+def inline_iron_laws(body: str, laws: Iterable[str], target: str) -> str:
+    """Append or replace an inlined Iron Laws section."""
+    if target == "claude":
+        return body
+
+    laws_list = list(laws)
+    if not laws_list:
+        return body
+
+    bullets = "\n".join(f"- {law}" for law in laws_list)
+    block = f"\n\n{_IRON_LAW_HEADER}\n\n{bullets}\n"
+    pattern = re.compile(
+        rf"\n*{re.escape(_IRON_LAW_HEADER)}\n.*?(?=\n## |\Z)",
+        re.DOTALL,
+    )
+    cleaned = pattern.sub("", body).rstrip()
+    return cleaned + block

--- a/scripts/port_lib/skill_transforms.py
+++ b/scripts/port_lib/skill_transforms.py
@@ -1,4 +1,4 @@
-"""Pure source-to-target transforms for Agent Skills."""
+"""Shared source-to-target transforms for Agent Skills."""
 
 from __future__ import annotations
 
@@ -7,18 +7,7 @@ import shutil
 from pathlib import Path
 from typing import Iterable
 
-AGENTSKILLS_FIELDS = {"name", "description", "license"}
-
-CLAUDE_EXTENSION_FIELDS = {
-    "effort",
-    "allowed-tools",
-    "disallowed-tools",
-    "model",
-    "memory",
-    "skills",
-    "permissionMode",
-    "omitClaudeMd",
-}
+AGENTSKILLS_FIELDS = {"name", "description", "license", "compatibility", "metadata"}
 
 
 def normalize_skill_name(name: str) -> str:
@@ -37,15 +26,22 @@ def transform_frontmatter(data: dict, target: str) -> dict:
         raise ValueError(f"Unknown target: {target}")
 
     output: dict = {}
-    metadata: dict = {}
 
     for key, value in data.items():
         if key == "name":
             output["name"] = normalize_skill_name(value)
         elif key in AGENTSKILLS_FIELDS:
             output[key] = value
-        else:
-            metadata[key] = value
+
+    metadata = output.get("metadata")
+    if metadata is not None and (
+        not isinstance(metadata, dict)
+        or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in metadata.items()
+        )
+    ):
+        raise ValueError("Agent Skills metadata must be a string-to-string mapping")
 
     if isinstance(output.get("description"), str):
         output["description"] = rewrite_slash_commands(
@@ -53,8 +49,6 @@ def transform_frontmatter(data: dict, target: str) -> dict:
             target,
         )
 
-    if metadata:
-        output["metadata"] = metadata
     return output
 
 
@@ -94,7 +88,7 @@ def port_references(
             text = rewrite_slash_commands(text, target)
             output.write_text(text, encoding="utf-8")
         else:
-            output.write_bytes(src.read_bytes())
+            shutil.copy2(src, output)
 
 
 def rewrite_slash_commands(body: str, target: str) -> str:
@@ -102,7 +96,7 @@ def rewrite_slash_commands(body: str, target: str) -> str:
     if target == "claude":
         return body
     if target == "codex":
-        return _SLASH_CMD_RE.sub(r"\1-\2", body)
+        return _SLASH_CMD_RE.sub(r"$\1-\2", body)
     if target in ("pi", "opencode"):
         return _SLASH_CMD_RE.sub(r"/\1-\2", body)
     raise ValueError(f"Unknown target: {target}")

--- a/scripts/tests/test_frontmatter.py
+++ b/scripts/tests/test_frontmatter.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.port_lib.frontmatter import Frontmatter, parse, parse_file, write_file
+
+
+def test_parse_round_trips_frontmatter_and_body() -> None:
+    text = """---
+name: phx:plan
+description: "Plán with unicode"
+paths:
+  - "**/*.ex"
+---
+# Plan
+
+Body text.
+"""
+
+    parsed = parse(text)
+
+    assert parsed.data == {
+        "name": "phx:plan",
+        "description": "Plán with unicode",
+        "paths": ["**/*.ex"],
+    }
+    assert parsed.body == "# Plan\n\nBody text.\n"
+    assert parse(parsed.dump()) == parsed
+
+
+def test_parse_preserves_markdown_without_frontmatter() -> None:
+    text = "# Plain Markdown\n\nNo metadata.\n"
+
+    assert parse(text) == Frontmatter(data={}, body=text)
+    assert parse(text).dump() == text
+
+
+def test_parse_reports_source_for_missing_closer() -> None:
+    with pytest.raises(ValueError, match=r"skill/SKILL\.md: malformed frontmatter"):
+        parse("---\nname: broken\n", source="skill/SKILL.md")
+
+
+@pytest.mark.parametrize("yaml_value", ["- one\n- two", "plain scalar"])
+def test_parse_rejects_non_mapping_frontmatter(yaml_value: str) -> None:
+    text = f"---\n{yaml_value}\n---\nBody\n"
+
+    with pytest.raises(ValueError, match="frontmatter must be a mapping"):
+        parse(text)
+
+
+def test_parse_file_and_write_file(tmp_path) -> None:
+    source = tmp_path / "source.md"
+    output = tmp_path / "output.md"
+    source.write_text("---\nname: testing\n---\n# Body\n", encoding="utf-8")
+
+    parsed = parse_file(source)
+    write_file(output, parsed)
+
+    assert output.read_text(encoding="utf-8") == parsed.dump()

--- a/scripts/tests/test_frontmatter.py
+++ b/scripts/tests/test_frontmatter.py
@@ -40,12 +40,32 @@ def test_parse_reports_source_for_missing_closer() -> None:
         parse("---\nname: broken\n", source="skill/SKILL.md")
 
 
-@pytest.mark.parametrize("yaml_value", ["- one\n- two", "plain scalar"])
+@pytest.mark.parametrize(
+    "yaml_value",
+    ["- one\n- two", "plain scalar", "false", "0", "[]", '""'],
+)
 def test_parse_rejects_non_mapping_frontmatter(yaml_value: str) -> None:
     text = f"---\n{yaml_value}\n---\nBody\n"
 
     with pytest.raises(ValueError, match="frontmatter must be a mapping"):
         parse(text)
+
+
+@pytest.mark.parametrize("opener", ["----", "---suffix", "--- "])
+def test_parse_requires_exact_opening_delimiter(opener: str) -> None:
+    text = f"{opener}\nordinary Markdown\n---\n"
+
+    assert parse(text) == Frontmatter(data={}, body=text)
+
+
+def test_parse_rejects_duplicate_keys_with_source() -> None:
+    text = "---\nname: first\nname: second\n---\nBody\n"
+
+    with pytest.raises(
+        ValueError,
+        match=r"(?s)skill/SKILL\.md: invalid YAML.*duplicate key",
+    ):
+        parse(text, source="skill/SKILL.md")
 
 
 def test_parse_file_and_write_file(tmp_path) -> None:

--- a/scripts/tests/test_skill_transforms.py
+++ b/scripts/tests/test_skill_transforms.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.port_lib.skill_transforms import (
+    inline_iron_laws,
+    normalize_skill_name,
+    port_references,
+    rewrite_reference_paths,
+    rewrite_slash_commands,
+    transform_frontmatter,
+)
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("phx:plan", "phx-plan"),
+        ("lv:assigns", "lv-assigns"),
+        ("ecto:n1-check", "ecto-n1-check"),
+        ("liveview-patterns", "liveview-patterns"),
+        ("", ""),
+    ],
+)
+def test_normalize_skill_name(source: str, expected: str) -> None:
+    assert normalize_skill_name(source) == expected
+
+
+def test_claude_frontmatter_is_preserved() -> None:
+    data = {
+        "name": "phx:plan",
+        "description": "Use after /phx:review.",
+        "effort": "high",
+        "paths": ["**/*.ex"],
+    }
+
+    transformed = transform_frontmatter(data, "claude")
+
+    assert transformed == data
+    assert transformed is not data
+
+
+@pytest.mark.parametrize("target", ["codex", "pi", "opencode"])
+def test_non_claude_frontmatter_preserves_extensions_in_metadata(target: str) -> None:
+    data = {
+        "name": "phx:plan",
+        "description": "Use after /phx:review.",
+        "effort": "high",
+        "paths": ["**/*.ex"],
+    }
+
+    transformed = transform_frontmatter(data, target)
+
+    assert transformed["name"] == "phx-plan"
+    assert transformed["metadata"] == {
+        "effort": "high",
+        "paths": ["**/*.ex"],
+    }
+    assert "/phx:review" not in transformed["description"]
+
+
+def test_transform_frontmatter_rejects_unknown_target() -> None:
+    with pytest.raises(ValueError, match="Unknown target: other"):
+        transform_frontmatter({"name": "testing"}, "other")
+
+
+def test_reference_paths_are_relative_outside_claude() -> None:
+    body = "Read `${CLAUDE_SKILL_DIR}/references/nested/example.md`."
+
+    assert rewrite_reference_paths(body, "codex") == (
+        "Read `references/nested/example.md`."
+    )
+    assert rewrite_reference_paths(body, "claude") == body
+
+
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    [
+        ("claude", "Run /phx:plan, /lv:assigns, and /ecto:n1-check."),
+        ("codex", "Run phx-plan, lv-assigns, and ecto-n1-check."),
+        ("pi", "Run /phx-plan, /lv-assigns, and /ecto-n1-check."),
+        ("opencode", "Run /phx-plan, /lv-assigns, and /ecto-n1-check."),
+    ],
+)
+def test_rewrite_slash_commands(target: str, expected: str) -> None:
+    body = "Run /phx:plan, /lv:assigns, and /ecto:n1-check."
+
+    assert rewrite_slash_commands(body, target) == expected
+
+
+def test_rewrite_slash_commands_rejects_unknown_target() -> None:
+    with pytest.raises(ValueError, match="Unknown target: other"):
+        rewrite_slash_commands("Run /phx:plan.", "other")
+
+
+def test_port_references_transforms_markdown_and_preserves_binary(tmp_path) -> None:
+    source = tmp_path / "source"
+    destination = tmp_path / "destination"
+    source.mkdir()
+    (source / "guide.md").write_text(
+        "Use /phx:review and read ${CLAUDE_SKILL_DIR}/references/details.md.\n",
+        encoding="utf-8",
+    )
+    payload = b"\x00\x01\xff"
+    (source / "asset.bin").write_bytes(payload)
+
+    port_references(source, destination, "codex")
+
+    assert (destination / "guide.md").read_text(encoding="utf-8") == (
+        "Use phx-review and read references/details.md.\n"
+    )
+    assert (destination / "asset.bin").read_bytes() == payload
+
+
+def test_inline_iron_laws_is_idempotent() -> None:
+    body = "# Skill\n\nInstructions.\n"
+    laws = ["Do one thing", "Do another thing"]
+
+    once = inline_iron_laws(body, laws, "codex")
+    twice = inline_iron_laws(once, laws, "codex")
+
+    assert twice == once
+    assert once.count("## Iron Laws (Inlined)") == 1
+    assert "- Do one thing" in once
+
+
+def test_inline_iron_laws_preserves_claude_body() -> None:
+    body = "# Skill\n"
+
+    assert inline_iron_laws(body, ["Law"], "claude") == body

--- a/scripts/tests/test_skill_transforms.py
+++ b/scripts/tests/test_skill_transforms.py
@@ -41,10 +41,12 @@ def test_claude_frontmatter_is_preserved() -> None:
 
 
 @pytest.mark.parametrize("target", ["codex", "pi", "opencode"])
-def test_non_claude_frontmatter_preserves_extensions_in_metadata(target: str) -> None:
+def test_non_claude_frontmatter_drops_claude_extensions(target: str) -> None:
     data = {
         "name": "phx:plan",
         "description": "Use after /phx:review.",
+        "compatibility": "Requires Elixir",
+        "metadata": {"author": "example"},
         "effort": "high",
         "paths": ["**/*.ex"],
     }
@@ -52,11 +54,19 @@ def test_non_claude_frontmatter_preserves_extensions_in_metadata(target: str) ->
     transformed = transform_frontmatter(data, target)
 
     assert transformed["name"] == "phx-plan"
-    assert transformed["metadata"] == {
-        "effort": "high",
-        "paths": ["**/*.ex"],
-    }
+    assert transformed["compatibility"] == "Requires Elixir"
+    assert transformed["metadata"] == {"author": "example"}
+    assert "effort" not in transformed
+    assert "paths" not in transformed
     assert "/phx:review" not in transformed["description"]
+
+
+def test_non_claude_frontmatter_rejects_non_string_metadata() -> None:
+    with pytest.raises(ValueError, match="string-to-string mapping"):
+        transform_frontmatter(
+            {"name": "testing", "metadata": {"paths": ["**/*.ex"]}},
+            "codex",
+        )
 
 
 def test_transform_frontmatter_rejects_unknown_target() -> None:
@@ -77,7 +87,7 @@ def test_reference_paths_are_relative_outside_claude() -> None:
     ("target", "expected"),
     [
         ("claude", "Run /phx:plan, /lv:assigns, and /ecto:n1-check."),
-        ("codex", "Run phx-plan, lv-assigns, and ecto-n1-check."),
+        ("codex", "Run $phx-plan, $lv-assigns, and $ecto-n1-check."),
         ("pi", "Run /phx-plan, /lv-assigns, and /ecto-n1-check."),
         ("opencode", "Run /phx-plan, /lv-assigns, and /ecto-n1-check."),
     ],
@@ -107,7 +117,7 @@ def test_port_references_transforms_markdown_and_preserves_binary(tmp_path) -> N
     port_references(source, destination, "codex")
 
     assert (destination / "guide.md").read_text(encoding="utf-8") == (
-        "Use phx-review and read references/details.md.\n"
+        "Use $phx-review and read references/details.md.\n"
     )
     assert (destination / "asset.bin").read_bytes() == payload
 


### PR DESCRIPTION
## Summary

Extract safe, runtime-independent transformation primitives from the multi-agent port work so future targets can share frontmatter parsing and skill rewrites without coupling them to PR #46's unfinished orchestration.

## What changes

- Adds a strict, normalizing YAML frontmatter parser/writer that preserves Markdown bodies, rejects duplicate keys, rejects non-mapping values (including falsy scalars/lists), and requires exact delimiters.
- Adds shared helpers for name normalization, portable Agent Skills frontmatter projection, resource copying, slash-command rewrites, and Iron Law inlining.
- Keeps target-specific Claude extensions out of portable `metadata`; existing Agent Skills metadata must be a string-to-string mapping.
- Preserves resource bytes and executable modes.
- Extends the existing Python test and lint coverage to include `scripts/`.

This PR is intentionally inert: it does not generate or activate any target, and it does not modify `plugins/elixir-phoenix/` or `CLAUDE.md`.

## Verification

- `python3 -m pytest scripts/tests/ -q`
- `make test-quick`
- `make lint`
- `ruff check scripts/ --select E,F,W --ignore E501,E402`
- `ruff format --check scripts/`
