### PR TITLE
docs(amp): install skills directly from GitHub

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,6 +6,7 @@ STAGED_MD=$(git diff --cached --name-only --diff-filter=ACM | grep '\.md$' || tr
 STAGED_JSON=$(git diff --cached --name-only --diff-filter=ACM | grep '\.json$' || true)
 STAGED_SH=$(git diff --cached --name-only --diff-filter=ACM | grep '\.sh$' || true)
 STAGED_SKILL_AGENT=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^plugins/[^/]+/(skills|agents)/' || true)
+STAGED_CANONICAL_SKILLS=$(git diff --cached --name-only --diff-filter=ACMRD | grep -E '^plugins/elixir-phoenix/skills/' || true)
 STAGED_EVAL_FW=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^lab/eval/' || true)
 
 # Markdown lint
@@ -61,6 +62,25 @@ if [ -n "$STAGED_SKILL_AGENT" ]; then
   if ! make eval > /tmp/precommit-eval.log 2>&1; then
     echo "Plugin eval failed. See /tmp/precommit-eval.log or run: make eval-fix"
     tail -30 /tmp/precommit-eval.log
+    exit 1
+  fi
+fi
+
+# Generated Amp target drift (only when canonical Elixir/Phoenix skills change).
+# Validate first, then require any regenerated target edits to be staged so the
+# source and projection land in the same commit. CI repeats the drift check from
+# the committed tree for contributors without Husky.
+if [ -n "$STAGED_CANONICAL_SKILLS" ]; then
+  echo "→ Checking generated Amp skills..."
+  if ! make amp-skills-validate > /tmp/precommit-amp-skills.log 2>&1; then
+    echo "Amp skills are out of date. Run: make amp-skills-sync"
+    tail -30 /tmp/precommit-amp-skills.log
+    exit 1
+  fi
+
+  UNTRACKED_AMP_SKILLS=$(git ls-files --others --exclude-standard -- targets/amp/skills)
+  if ! git diff --quiet -- targets/amp/skills || [ -n "$UNTRACKED_AMP_SKILLS" ]; then
+    echo "Generated Amp skill changes are not staged. Run: git add targets/amp/skills"
     exit 1
   fi
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,19 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Amp target drift pre-commit guard** — canonical changes under
+  `plugins/elixir-phoenix/skills/` now trigger `make amp-skills-validate` and
+  require regenerated `targets/amp/skills/` changes to be staged. CI retains
+  the same drift check as the authoritative fallback. Contributors can run
+  `make amp-skills-sync` to regenerate and verify the complete target in one
+  command.
+
 ### Changed
+
+- **Amp installation no longer requires cloning this repository** — the primary
+  project-local and global instructions now install all 51 generated skills
+  directly from the GitHub `targets/amp/skills` tree. Update instructions also
+  clarify that Amp copies skills and requires an explicit `--overwrite` install.
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint lint-fix eval eval-all eval-fix eval-full eval-ci eval-triggers eval-tournament eval-skills eval-agents eval-multimodel eval-compare-models test validate amp-skills amp-skills-validate security ci clean
+.PHONY: help lint lint-fix eval eval-all eval-fix eval-full eval-ci eval-triggers eval-tournament eval-skills eval-agents eval-multimodel eval-compare-models test validate amp-skills amp-skills-sync amp-skills-validate security ci clean
 
 # Default target
 help: ## Show available commands
@@ -64,6 +64,10 @@ validate: ## Run claude plugin validate on plugin structure
 
 amp-skills: ## Generate Amp skills from the canonical Claude plugin
 	@python3 -m scripts.build_amp_skills
+
+amp-skills-sync: ## Regenerate and verify the committed Amp target
+	@$(MAKE) amp-skills
+	@$(MAKE) amp-skills-validate
 
 amp-skills-validate: ## Check committed Amp skills for generated drift
 	@python3 -m scripts.build_amp_skills --check

--- a/README.md
+++ b/README.md
@@ -152,17 +152,21 @@ Project-local installation is recommended because it keeps the Elixir/Phoenix
 guidance scoped to the repository where it applies:
 
 ```bash
-git clone https://github.com/oliver-kriska/claude-elixir-phoenix.git
-
 # Install into one Elixir/Phoenix project
 cd /path/to/your-phoenix-project
-amp skill add /path/to/claude-elixir-phoenix/targets/amp/skills \
+amp skill add \
+  https://github.com/oliver-kriska/claude-elixir-phoenix/tree/main/targets/amp/skills \
   --target "$PWD/.agents/skills"
 
 # Or install for every Amp workspace
-cd /path/to/claude-elixir-phoenix
-amp skill add ./targets/amp/skills --global
+amp skill add \
+  https://github.com/oliver-kriska/claude-elixir-phoenix/tree/main/targets/amp/skills \
+  --global
 ```
+
+Amp copies skills at installation time; it does not update them automatically.
+Rerun the same command with `--overwrite` to install the latest version from
+`main`. Cloning this repository is only necessary for local development.
 
 Namespaced Claude commands use hyphenated Amp names: `/phx:plan` becomes
 `phx-plan`, `/ecto:n1-check` becomes `ecto-n1-check`, and so on. Start a fresh

--- a/docs/amp.md
+++ b/docs/amp.md
@@ -24,12 +24,7 @@ before relying on a workflow or administration skill.
 ## Requirements
 
 1. Install [Amp](https://ampcode.com/).
-2. Clone this repository.
-3. Run the installation from the Elixir/Phoenix project where Amp will work.
-
-```bash
-git clone https://github.com/oliver-kriska/claude-elixir-phoenix.git
-```
+2. Run the installation from the Elixir/Phoenix project where Amp will work.
 
 ## Install in one project (recommended)
 
@@ -37,10 +32,8 @@ Project-local installation keeps this opinionated guidance scoped to an
 Elixir/Phoenix repository. From the project that should use the skills:
 
 ```bash
-mkdir -p .agents/skills
-
 amp skill add \
-  /path/to/claude-elixir-phoenix/targets/amp/skills \
+  https://github.com/oliver-kriska/claude-elixir-phoenix/tree/main/targets/amp/skills \
   --target "$PWD/.agents/skills"
 ```
 
@@ -66,8 +59,9 @@ skills from `.agents/skills/`.
 Use a global installation only if most of your Amp work is Elixir/Phoenix:
 
 ```bash
-cd /path/to/claude-elixir-phoenix
-amp skill add ./targets/amp/skills --global
+amp skill add \
+  https://github.com/oliver-kriska/claude-elixir-phoenix/tree/main/targets/amp/skills \
+  --global
 ```
 
 Amp installs global skills in `~/.config/agents/skills/`.
@@ -194,21 +188,25 @@ if an isolated compatibility test requires it.
 
 ## Update or remove
 
-Pull the latest source, then reinstall with `--overwrite`:
+Amp copies skills when `amp skill add` runs; starting Amp does not fetch updates
+automatically. Rerun the remote installation with `--overwrite` to install the
+latest generated skills from `main`:
 
 ```bash
-cd /path/to/claude-elixir-phoenix
-git pull --ff-only
-
-amp skill add ./targets/amp/skills \
-  --target /path/to/your-phoenix-project/.agents/skills \
+cd /path/to/your-phoenix-project
+amp skill add \
+  https://github.com/oliver-kriska/claude-elixir-phoenix/tree/main/targets/amp/skills \
+  --target "$PWD/.agents/skills" \
   --overwrite
 ```
 
 For a global update:
 
 ```bash
-amp skill add ./targets/amp/skills --global --overwrite
+amp skill add \
+  https://github.com/oliver-kriska/claude-elixir-phoenix/tree/main/targets/amp/skills \
+  --global \
+  --overwrite
 ```
 
 `--overwrite` replaces installed skills with the same name. It may leave an
@@ -291,12 +289,25 @@ active merely because their workflow skill is installed.
 ## Maintain the generated target
 
 Never edit `targets/amp/skills` manually. Change the canonical Claude skill,
-then regenerate:
+then regenerate and verify the complete target with one command:
 
 ```bash
-make amp-skills
-make amp-skills-validate
+make amp-skills-sync
+git add targets/amp/skills
 ```
+
+`make amp-skills` remains available when generation without a follow-up drift
+check is useful; `make amp-skills-validate` is the read-only check used by hooks
+and CI.
+
+The Husky pre-commit hook runs `make amp-skills-validate` only when files under
+`plugins/elixir-phoenix/skills/` are staged. It blocks the commit when the Amp
+target has drift or regenerated target changes were not staged. GitHub Actions
+runs the same drift check for every pull request and push to protect contributors
+who do not have Husky installed.
+
+Clone the repository only when changing the canonical plugin or generator. Amp
+users installing the published skills should use the remote commands above.
 
 The builder:
 


### PR DESCRIPTION
## Summary

Make the Amp installation a one-command GitHub install instead of requiring users to clone this repository, and prevent canonical skill changes from landing with a stale generated Amp target.

## Changes

- Use the tested `tree/main/targets/amp/skills` URL for project-local and global installation.
- Document explicit `--overwrite` updates because Amp copies skills rather than updating automatically.
- Add `make amp-skills-sync` to regenerate and immediately validate all 51 generated skills.
- Scope the Husky pre-commit drift guard to canonical `plugins/elixir-phoenix/skills/` changes and require regenerated output to be staged.
- Retain the existing unconditional GitHub Actions drift check as the authoritative fallback.

## Verification

- Installed 51 skills from the documented GitHub tree URL in a temporary target.
- `make amp-skills-sync`
- `make lint`
- `npx markdownlint README.md docs/amp.md CHANGELOG.md`
- `bash -n .husky/pre-commit`
- `shellcheck .husky/pre-commit`
- Real stale-target probe was rejected by the pre-commit hook.
- `git diff --check`