### PR TITLE
fix(ci): validate stacked pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,8 @@ name: Quality Gate
 on:
   push:
     branches: [main]
+  # Validate stacked PRs too; GitHub evaluates this workflow from the PR base.
   pull_request:
-    branches: [main]
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary

Run the existing Quality Gate for pull requests targeting any branch, not only `main`.

This lets stacked PRs receive normal hosted validation while preserving the existing `push` trigger exclusively for `main`.

## Why

PRs #94 and #95 are intentionally stacked and mergeable, but GitHub reports no checks because `.github/workflows/lint.yml` filters `pull_request` events to `branches: [main]`. Changing a PR base later also does not trigger the workflow under the default event types.

GitHub evaluates `pull_request` workflows from the base branch, so this does not switch to `pull_request_target` or grant fork code elevated secrets/permissions.

## Validation

- workflow YAML parsed successfully with `push.branches == [main]`
- `pull_request` parsed without a base-branch filter
- `yamllint` clean
- `git diff --check` clean
- `actionlint` found only the existing SC2044 warning in the unchanged JSON-validation loop
