### PR TITLE
test(port): guard generated target snapshots

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -131,6 +131,9 @@ jobs:
       - name: Check OpenCode generated skills
         run: python3 -m scripts.build_opencode_skills --check
 
+      - name: Check generated target golden snapshots
+        run: python3 -m scripts.generated_target_snapshots --check
+
   eval:
     name: Skill & Agent Eval
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Generated-target golden snapshots** — CI now pins aggregate path, byte, and
+  executable-mode digests for Amp, Codex, Pi, and OpenCode before shared
+  generator refactoring. Target changes require an explicit reviewed snapshot
+  update instead of silently redefining the baseline.
+
 - **Package-specific `/phx:learn-from-fix` routing** — verified fixes and
   explicit user-taught rules can now be saved as native background skills with
   `--library <package> --scope personal|project`. The workflow reads locked

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint lint-fix eval eval-all eval-fix eval-full eval-ci eval-triggers eval-tournament eval-skills eval-agents eval-multimodel eval-compare-models test validate amp-skills amp-skills-sync amp-skills-validate codex-skills codex-skills-sync codex-skills-validate pi-skills pi-skills-sync pi-skills-validate opencode-skills opencode-skills-sync opencode-skills-validate security ci clean
+.PHONY: help lint lint-fix eval eval-all eval-fix eval-full eval-ci eval-triggers eval-tournament eval-skills eval-agents eval-multimodel eval-compare-models test validate amp-skills amp-skills-sync amp-skills-validate codex-skills codex-skills-sync codex-skills-validate pi-skills pi-skills-sync pi-skills-validate opencode-skills opencode-skills-sync opencode-skills-validate generated-skills-snapshots generated-skills-snapshots-validate security ci clean
 
 # Default target
 help: ## Show available commands
@@ -102,6 +102,12 @@ opencode-skills-sync: ## Regenerate and verify the committed OpenCode target
 opencode-skills-validate: ## Check committed OpenCode skills for generated drift
 	@python3 -m scripts.build_opencode_skills --check
 
+generated-skills-snapshots: ## Update reviewed byte-and-mode digests for all targets
+	@python3 -m scripts.generated_target_snapshots
+
+generated-skills-snapshots-validate: ## Check all targets against golden digests
+	@python3 -m scripts.generated_target_snapshots --check
+
 # --- Security ---
 
 security: ## SkillSpector scan of all skills + agents (skips if not installed)
@@ -114,7 +120,7 @@ security: ## SkillSpector scan of all skills + agents (skips if not installed)
 
 # --- CI (full pipeline) ---
 
-ci: lint test validate amp-skills-validate codex-skills-validate pi-skills-validate opencode-skills-validate eval-all security ## Full CI: lint + test + validate + eval + security (same as GitHub Actions)
+ci: lint test validate amp-skills-validate codex-skills-validate pi-skills-validate opencode-skills-validate generated-skills-snapshots-validate eval-all security ## Full CI: lint + test + validate + eval + security (same as GitHub Actions)
 
 # --- Clean ---
 

--- a/scripts/generated_target_snapshots.json
+++ b/scripts/generated_target_snapshots.json
@@ -1,0 +1,25 @@
+{
+  "format": 1,
+  "targets": {
+    "amp": {
+      "entries": 379,
+      "files": 251,
+      "sha256": "d01ed7ed77eaafdbf21c489b9e6e7254bdbabc3340192c3a8838ad11147d23da"
+    },
+    "codex": {
+      "entries": 381,
+      "files": 252,
+      "sha256": "96485e8aa50aedb73eeeecc97e25b14f8debf451613fb5c4c64a3aa8ef153aa3"
+    },
+    "opencode": {
+      "entries": 379,
+      "files": 251,
+      "sha256": "e61918fb3cdd4f80c7725562dbdbe152dc6f0d86e8214cb984e47c86dc8dff45"
+    },
+    "pi": {
+      "entries": 380,
+      "files": 252,
+      "sha256": "1c2de77ba36005b4125e0bd9d14874583c28abdb174ed43196d4ed0322f68853"
+    }
+  }
+}

--- a/scripts/generated_target_snapshots.py
+++ b/scripts/generated_target_snapshots.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Update or verify golden byte-and-mode digests for generated runtime targets."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import stat
+import sys
+from pathlib import Path
+
+from .port_lib import REPO_ROOT, TARGETS_DIR
+
+TARGET_NAMES = ("amp", "codex", "pi", "opencode")
+SNAPSHOT_FILE = REPO_ROOT / "scripts" / "generated_target_snapshots.json"
+FORMAT_VERSION = 1
+
+
+def snapshot_tree(root: Path) -> dict[str, int | str]:
+    """Hash relative paths, kinds, file bytes, and executable mode bits."""
+    try:
+        root_mode = root.lstat().st_mode
+    except FileNotFoundError as error:
+        raise ValueError(f"{root}: generated target does not exist") from error
+    if stat.S_ISLNK(root_mode) or not stat.S_ISDIR(root_mode):
+        raise ValueError(f"{root}: generated target must be a real directory")
+
+    digest = hashlib.sha256()
+    entries = 0
+    files = 0
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root).as_posix()
+        mode = path.lstat().st_mode
+        if stat.S_ISLNK(mode):
+            raise ValueError(f"{path}: generated symlinks are not supported")
+        if stat.S_ISDIR(mode):
+            kind = "directory"
+            executable = 0
+            payload = b""
+        elif stat.S_ISREG(mode):
+            kind = "file"
+            executable = int(bool(mode & stat.S_IXUSR))
+            payload = path.read_bytes()
+            files += 1
+        else:
+            raise ValueError(f"{path}: generated special files are not supported")
+        record = json.dumps(
+            [relative, kind, executable, hashlib.sha256(payload).hexdigest()],
+            separators=(",", ":"),
+            ensure_ascii=True,
+        )
+        digest.update(record.encode("utf-8") + b"\n")
+        entries += 1
+    if files == 0:
+        raise ValueError(f"{root}: generated target contains no files")
+    return {"sha256": digest.hexdigest(), "entries": entries, "files": files}
+
+
+def current_snapshots() -> dict:
+    return {
+        "format": FORMAT_VERSION,
+        "targets": {name: snapshot_tree(TARGETS_DIR / name) for name in TARGET_NAMES},
+    }
+
+
+def update() -> None:
+    SNAPSHOT_FILE.write_text(
+        json.dumps(current_snapshots(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"[generated-snapshots] updated {SNAPSHOT_FILE}")
+
+
+def check() -> int:
+    try:
+        expected = json.loads(SNAPSHOT_FILE.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        print(f"[generated-snapshots] invalid snapshot: {error}", file=sys.stderr)
+        return 1
+    try:
+        actual = current_snapshots()
+    except (OSError, ValueError) as error:
+        print(
+            f"[generated-snapshots] invalid generated target: {error}", file=sys.stderr
+        )
+        return 1
+    if expected == actual:
+        print("[generated-snapshots] OK: Amp, Codex, Pi, OpenCode")
+        return 0
+    for name in TARGET_NAMES:
+        if expected.get("targets", {}).get(name) != actual["targets"][name]:
+            print(
+                f"[generated-snapshots] {name} digest changed; regenerate the target, "
+                "review its diff, then update snapshots",
+                file=sys.stderr,
+            )
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="scripts.generated_target_snapshots")
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    if args.check:
+        return check()
+    update()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_generated_target_snapshots.py
+++ b/scripts/tests/test_generated_target_snapshots.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import generated_target_snapshots as snapshots
+
+
+def test_snapshot_detects_path_content_and_executable_changes(tmp_path: Path) -> None:
+    root = tmp_path / "target"
+    root.mkdir()
+    script = root / "run.sh"
+    script.write_text("#!/bin/sh\n", encoding="utf-8")
+    script.chmod(0o644)
+    baseline = snapshots.snapshot_tree(root)
+
+    script.write_text("#!/bin/sh\necho changed\n", encoding="utf-8")
+    assert snapshots.snapshot_tree(root) != baseline
+    script.write_text("#!/bin/sh\n", encoding="utf-8")
+    script.chmod(0o700)
+    assert snapshots.snapshot_tree(root) != baseline
+
+    executable = snapshots.snapshot_tree(root)
+    script.chmod(0o755)
+    assert snapshots.snapshot_tree(root) == executable
+
+    (root / "added.txt").write_text("added\n", encoding="utf-8")
+    assert snapshots.snapshot_tree(root) != executable
+
+
+def test_snapshot_rejects_invalid_target_roots(tmp_path: Path) -> None:
+    missing = tmp_path / "missing"
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    regular_file = tmp_path / "target-file"
+    regular_file.write_text("not a directory\n", encoding="utf-8")
+    symlink = tmp_path / "target-link"
+    symlink.symlink_to(empty, target_is_directory=True)
+
+    for root in (missing, empty, regular_file, symlink):
+        try:
+            snapshots.snapshot_tree(root)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"expected invalid target rejection for {root}")
+
+
+def test_check_is_read_only_and_detects_drift(tmp_path: Path, monkeypatch) -> None:
+    targets = tmp_path / "targets"
+    for name in snapshots.TARGET_NAMES:
+        target = targets / name
+        target.mkdir(parents=True)
+        (target / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+    snapshot_file = tmp_path / "snapshots.json"
+    monkeypatch.setattr(snapshots, "TARGETS_DIR", targets)
+    monkeypatch.setattr(snapshots, "SNAPSHOT_FILE", snapshot_file)
+
+    snapshots.update()
+    baseline = snapshot_file.read_bytes()
+    assert snapshots.check() == 0
+
+    (targets / "codex" / "SKILL.md").write_text("changed\n", encoding="utf-8")
+    assert snapshots.check() == 1
+    assert snapshot_file.read_bytes() == baseline
+
+
+def test_repository_snapshots_cover_all_targets() -> None:
+    expected = json.loads(snapshots.SNAPSHOT_FILE.read_text(encoding="utf-8"))
+    assert expected["format"] == snapshots.FORMAT_VERSION
+    assert tuple(expected["targets"]) == tuple(sorted(snapshots.TARGET_NAMES))


### PR DESCRIPTION
## Summary

- add deterministic golden snapshots for generated Amp, Codex, Pi, and OpenCode target trees
- hash relative paths, entry kinds, file bytes, and Git-compatible executable state
- require explicit snapshot updates after reviewing generated-target changes
- validate snapshots in CI only after the existing detailed per-runtime drift checks

This establishes a hard baseline before shared generator refactoring while keeping each runtime's detailed generator validation authoritative. It is part of #90.

## Safety properties

- rejects missing, empty, symlinked, and non-directory target roots
- rejects symlink and special-file entries
- ignores unstable filesystem metadata and umask-specific execute bits
- read-only validation detects content, path, and executable-state drift
- does not modify canonical Claude skills or any generated target
- all four generated targets remain at 51 skills

## Commands

```bash
make generated-skills-snapshots          # explicitly update reviewed snapshots
make generated-skills-snapshots-validate # read-only validation
```

## Validation

- `make ci`
  - 153 tests passed
  - Amp: 51 skills, drift-clean
  - Codex: 51 skills, drift-clean
  - Pi: 51 skills, drift-clean
  - OpenCode: 51 skills, drift-clean
  - golden snapshots: clean
  - skill/agent eval: passed
  - security: 77 components scanned, 0 flagged
- `ruff check scripts/generated_target_snapshots.py scripts/tests/test_generated_target_snapshots.py --select E,F,W --ignore E501,E402`
- `git diff --check`
- verified canonical sources and generated targets have no diff

## Stacked-PR note

This PR is independent and targets `main`. It may overlap mechanically with #98 in `.github/workflows/lint.yml`, but the changes are semantically compatible: #98 enables CI for stacked PR bases, while this PR adds the snapshot validation step after per-target drift validation.
