### PR TITLE
test(pi): add isolated runtime smoke harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   pushes, and accidental production Mix commands. The broad Claude hook set,
   async hooks, custom agents, and Tidewave MCP remain deferred.
 
-- **Optional runtime smoke harness** — `make codex-runtime-smoke` and
-  `make opencode-runtime-smoke` validate locally generated targets, native Codex
-  installation/enabled state, native OpenCode discovery, all 51 installed
-  skills, retained resources and modes, and fresh-process removal in isolated
-  temporary homes without credentials or model calls.
+- **Optional runtime smoke harness** — `make codex-runtime-smoke`,
+  `make pi-runtime-smoke`, and `make opencode-runtime-smoke` validate locally
+  generated targets, native installation or discovery, all 51 installed skills,
+  retained resources and modes, and fresh-process removal in isolated temporary
+  homes without requiring credentials or making model calls.
 
 - **Generated-target golden snapshots** — CI now pins aggregate path, byte, and
   executable-mode digests for Amp, Codex, Pi, and OpenCode before shared

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint lint-fix eval eval-all eval-fix eval-full eval-ci eval-triggers eval-tournament eval-skills eval-agents eval-multimodel eval-compare-models test validate amp-skills amp-skills-sync amp-skills-validate codex-skills codex-skills-sync codex-skills-validate codex-runtime-smoke pi-skills pi-skills-sync pi-skills-validate opencode-skills opencode-skills-sync opencode-skills-validate opencode-runtime-smoke generated-skills-sync generated-skills-snapshots generated-skills-snapshots-validate security ci clean
+.PHONY: help lint lint-fix eval eval-all eval-fix eval-full eval-ci eval-triggers eval-tournament eval-skills eval-agents eval-multimodel eval-compare-models test validate amp-skills amp-skills-sync amp-skills-validate codex-skills codex-skills-sync codex-skills-validate codex-runtime-smoke pi-skills pi-skills-sync pi-skills-validate pi-runtime-smoke opencode-skills opencode-skills-sync opencode-skills-validate opencode-runtime-smoke generated-skills-sync generated-skills-snapshots generated-skills-snapshots-validate security ci clean
 
 # Default target
 help: ## Show available commands
@@ -94,6 +94,9 @@ pi-skills-sync: ## Regenerate and verify the committed Pi target
 
 pi-skills-validate: ## Check committed Pi skills for generated drift
 	@python3 -m scripts.build_pi_skills --check
+
+pi-runtime-smoke: ## Optional: smoke-test local target with an isolated Pi runtime
+	@python3 -m scripts.runtime_smoke pi
 
 opencode-skills: ## Generate the OpenCode skills target
 	@python3 -m scripts.build_opencode_skills

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -1,7 +1,7 @@
 # Pi skills package
 
 The generated Pi package provides all 51 canonical Elixir/Phoenix skills and
-their bundled resources. It was tested with Pi **0.79.1**. This is a focused
+their bundled resources. It was tested with Pi **0.81.1**. This is a focused
 skills baseline, not full Claude Code feature parity.
 
 See the [runtime support matrix](runtime-support.md) for a concise comparison
@@ -127,7 +127,7 @@ pi install git:github.com/oliver-kriska/claude-elixir-phoenix
 ```
 
 The generated package manifest deliberately declares `pi.skills` as an array.
-Pi 0.79.1 expects resource values to be arrays; a string can prevent package
+Pi 0.81.1 expects resource values to be arrays; a string can prevent package
 resource discovery.
 
 ## Maintainer workflow
@@ -138,7 +138,16 @@ The Claude Code skills remain canonical. Never hand-edit `targets/pi`.
 make pi-skills           # regenerate targets/pi
 make pi-skills-sync      # regenerate, then verify committed output
 make pi-skills-validate  # read-only drift check
+make pi-runtime-smoke    # optional isolated native runtime acceptance
 ```
+
+The smoke target generates a temporary local Pi package, installs it with an
+isolated `HOME` and `PI_CODING_AGENT_DIR`, and uses RPC `get_commands` to verify
+all 51 native `/skill:*` commands without requiring credentials or making a
+model call. It also checks a retained executable resource byte-for-byte and
+mode-for-mode, removes the package, and confirms a fresh Pi process no longer
+discovers it. `PI_OFFLINE=1` and `PI_TELEMETRY=0` prevent startup network and
+telemetry activity.
 
 Generation stages and validates the complete package before replacing the target
 with in-process rollback. A failed build preserves the previous target. Drift

--- a/docs/runtime-support.md
+++ b/docs/runtime-support.md
@@ -41,7 +41,7 @@ installation and troubleshooting remain in the linked guides.
 | Deterministic generated target | Canonical source | Yes | Yes | Yes | Yes |
 | Mode-aware CI drift validation | Not applicable | Yes | Yes | Yes | Yes |
 | Golden target snapshot | Not applicable | Yes | Yes | Yes | Yes |
-| Isolated native smoke command | Not applicable | Deferred | Yes | Deferred | Yes |
+| Isolated native smoke command | Not applicable | Deferred | Yes | Yes | Yes |
 
 “External” Tidewave support means a skill may use Tidewave when the project and
 runtime already expose it. Generated flagship workflows must still complete
@@ -63,7 +63,7 @@ the supported installation and update mechanism. Start a fresh process after
 installing, updating, or removing skills because runtime discovery may be
 cached when a session starts.
 
-The current local acceptance baseline is Codex CLI 0.145.0, Pi 0.79.1, and
+The current local acceptance baseline is Codex CLI 0.145.0, Pi 0.81.1, and
 OpenCode 1.17.2. Amp uses standard Agent Skills rather than a repository-pinned
 runtime package version.
 
@@ -120,7 +120,7 @@ Every generated target must pass repository tests that prove:
    changes, and mode-only changes; and
 8. generation does not mutate canonical sources or another runtime target.
 
-The optional Codex and OpenCode smoke harnesses additionally verify native
+The optional Codex, Pi, and OpenCode smoke harnesses additionally verify native
 installation or discovery, all 51 skills, retained resources and executable
 modes, removal behavior, and fresh-process rediscovery. Behavioral acceptance
 uses controlled fixtures and requires `phx-investigate` to reproduce before

--- a/scripts/runtime_smoke.py
+++ b/scripts/runtime_smoke.py
@@ -17,16 +17,19 @@ from typing import Callable
 from scripts.port_lib import SOURCE_PLUGIN_DIR
 from scripts.port_lib import codex as codex_port
 from scripts.port_lib import opencode as opencode_port
+from scripts.port_lib import pi as pi_port
 
 EXPECTED_SKILLS = 51
 Run = Callable[..., subprocess.CompletedProcess[str]]
 EXECUTABLE_RESOURCE = Path("phx-watch-pr/scripts/watch-pr.sh")
+PI_SOURCE_EXECUTABLE = Path("watch-pr/scripts/watch-pr.sh")
 OPENCODE_ENV_OVERRIDES = (
     "OPENCODE_CONFIG",
     "OPENCODE_CONFIG_DIR",
     "OPENCODE_CONFIG_CONTENT",
     "OPENCODE_TEST_HOME",
 )
+PI_ENV_OVERRIDES = ("PI_PACKAGE_DIR",)
 
 
 def _run(
@@ -75,15 +78,20 @@ def _verify_tree(skills: Path) -> None:
         raise RuntimeError("no executable resource retained its mode")
 
 
-def _verify_resource(source_skills: Path, installed_skills: Path) -> None:
-    source = source_skills / EXECUTABLE_RESOURCE
-    installed = installed_skills / EXECUTABLE_RESOURCE
+def _verify_resource(
+    source_skills: Path,
+    installed_skills: Path,
+    source_resource: Path = EXECUTABLE_RESOURCE,
+    installed_resource: Path = EXECUTABLE_RESOURCE,
+) -> None:
+    source = source_skills / source_resource
+    installed = installed_skills / installed_resource
     if not installed.is_file():
-        raise RuntimeError(f"installed resource is missing: {EXECUTABLE_RESOURCE}")
+        raise RuntimeError(f"installed resource is missing: {installed_resource}")
     if installed.read_bytes() != source.read_bytes():
-        raise RuntimeError(f"installed resource bytes differ: {EXECUTABLE_RESOURCE}")
+        raise RuntimeError(f"installed resource bytes differ: {installed_resource}")
     if stat.S_IMODE(installed.stat().st_mode) != stat.S_IMODE(source.stat().st_mode):
-        raise RuntimeError(f"installed resource mode differs: {EXECUTABLE_RESOURCE}")
+        raise RuntimeError(f"installed resource mode differs: {installed_resource}")
 
 
 def _skill_records(records: list[dict], install: Path) -> dict[str, Path]:
@@ -98,6 +106,51 @@ def _skill_records(records: list[dict], install: Path) -> dict[str, Path]:
             raise RuntimeError("OpenCode returned duplicate or invalid generated skills")
         discovered[name] = location
     return discovered
+
+
+def _pi_skill_records(commands: list[dict], install: Path) -> dict[str, Path]:
+    install = install.resolve()
+    discovered: dict[str, Path] = {}
+    for item in commands:
+        source_info = item.get("sourceInfo")
+        if item.get("source") != "skill" or not isinstance(source_info, dict):
+            continue
+        location = Path(str(source_info.get("path", ""))).resolve()
+        if not location.is_relative_to(install):
+            continue
+        invocation = item.get("name")
+        if not isinstance(invocation, str) or not invocation.startswith("skill:"):
+            raise RuntimeError("Pi returned an invalid generated skill command")
+        name = invocation.removeprefix("skill:")
+        if not name or name in discovered:
+            raise RuntimeError("Pi returned duplicate or invalid generated skills")
+        discovered[name] = location
+    return discovered
+
+
+def _pi_commands(runner: Run, executable: str, env: dict[str, str], cwd: Path) -> list[dict]:
+    command = [executable, "--mode", "rpc", "--no-session", "--no-context-files"]
+    result = runner(
+        command,
+        env=env,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        input='{"id":"skills","type":"get_commands"}\n',
+    )
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"{' '.join(command)} failed: {detail}")
+    for line in result.stdout.splitlines():
+        response = json.loads(line)
+        if response.get("id") == "skills" and response.get("command") == "get_commands":
+            if not response.get("success"):
+                raise RuntimeError("Pi get_commands request failed")
+            commands = response.get("data", {}).get("commands")
+            if not isinstance(commands, list):
+                raise RuntimeError("Pi returned invalid get_commands data")
+            return commands
+    raise RuntimeError("Pi did not return a get_commands response")
 
 
 def smoke_codex(root: Path, runner: Run = subprocess.run) -> None:
@@ -144,6 +197,69 @@ def smoke_codex(root: Path, runner: Run = subprocess.run) -> None:
     print(f"[runtime-smoke] Codex {version}: {EXPECTED_SKILLS} skills OK")
 
 
+def smoke_pi(root: Path, runner: Run = subprocess.run) -> None:
+    home, agent_dir = root / "home", root / "agent"
+    workspace, package = root / "workspace", root / "package"
+    for path in (home, agent_dir, workspace, package / "targets"):
+        path.mkdir(parents=True)
+    generated = package / "targets/pi"
+    pi_port.build(SOURCE_PLUGIN_DIR, generated)
+    shutil.copy2(Path(__file__).parents[1] / "package.json", package / "package.json")
+    env = os.environ.copy()
+    for name in PI_ENV_OVERRIDES:
+        env.pop(name, None)
+    env |= {
+        "HOME": str(home),
+        "PI_CODING_AGENT_DIR": str(agent_dir),
+        "PI_CODING_AGENT_SESSION_DIR": str(root / "sessions"),
+        "PI_OFFLINE": "1",
+        "PI_SKIP_VERSION_CHECK": "1",
+        "PI_TELEMETRY": "0",
+    }
+    executable = _executable("pi", env)
+    version = _run(runner, [executable, "--version"], env, workspace).stdout.strip()
+    if not version:
+        raise RuntimeError("pi returned an empty version")
+    source = str(package.resolve())
+    _run(runner, [executable, "install", source], env, workspace)
+    listing = _run(runner, [executable, "list"], env, workspace).stdout
+    if source not in listing:
+        raise RuntimeError("Pi did not list the installed package")
+    _verify_tree(generated / "skills")
+    _verify_resource(
+        SOURCE_PLUGIN_DIR / "skills",
+        generated / "skills",
+        PI_SOURCE_EXECUTABLE,
+        EXECUTABLE_RESOURCE,
+    )
+    expected = {
+        path.parent.name: path.resolve()
+        for path in (generated / "skills").glob("*/SKILL.md")
+    }
+    discovered = _pi_skill_records(_pi_commands(runner, executable, env, workspace), generated)
+    if discovered != expected:
+        raise RuntimeError(
+            f"Pi discovered {len(discovered)} generated skills, "
+            f"expected the exact {len(expected)}-skill target"
+        )
+    _run(runner, [executable, "remove", source], env, workspace)
+    remaining = _pi_skill_records(_pi_commands(runner, executable, env, workspace), generated)
+    if remaining:
+        raise RuntimeError(f"Pi rediscovered {len(remaining)} generated skills after removal")
+    after = _run(runner, [executable, "list"], env, workspace).stdout
+    if source in after:
+        raise RuntimeError("Pi still lists the removed package")
+    if not package.is_dir():
+        raise RuntimeError("Pi removed the local package source")
+    _verify_resource(
+        SOURCE_PLUGIN_DIR / "skills",
+        generated / "skills",
+        PI_SOURCE_EXECUTABLE,
+        EXECUTABLE_RESOURCE,
+    )
+    print(f"[runtime-smoke] Pi {version}: {EXPECTED_SKILLS} skills OK")
+
+
 def smoke_opencode(root: Path, runner: Run = subprocess.run) -> None:
     roots = {name: root / name.lower() for name in ("HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME", "XDG_STATE_HOME")}
     for path in roots.values():
@@ -186,11 +302,13 @@ def smoke_opencode(root: Path, runner: Run = subprocess.run) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("runtime", choices=("codex", "opencode"))
+    parser.add_argument("runtime", choices=("codex", "pi", "opencode"))
     args = parser.parse_args()
     try:
         with tempfile.TemporaryDirectory(prefix=f"{args.runtime}-runtime-smoke-") as temporary:
-            {"codex": smoke_codex, "opencode": smoke_opencode}[args.runtime](Path(temporary))
+            {"codex": smoke_codex, "pi": smoke_pi, "opencode": smoke_opencode}[
+                args.runtime
+            ](Path(temporary))
     except (KeyError, OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
         print(f"[runtime-smoke] FAIL: {error}", file=sys.stderr)
         return 1

--- a/scripts/tests/test_runtime_smoke.py
+++ b/scripts/tests/test_runtime_smoke.py
@@ -106,6 +106,66 @@ def test_opencode_uses_all_isolated_xdg_roots_and_fresh_discovery(tmp_path, monk
     assert sum(call[0][1:] == ["debug", "skill", "--pure"] for call in calls) == 2
 
 
+def test_pi_uses_isolated_agent_dir_rpc_discovery_and_fresh_removal(tmp_path, monkeypatch) -> None:
+    canonical = tmp_path / "canonical"
+    source_resource = canonical / "skills" / runtime_smoke.PI_SOURCE_EXECUTABLE
+    source_resource.parent.mkdir(parents=True)
+    source_resource.write_text("#!/bin/sh\n")
+    source_resource.chmod(0o755)
+    monkeypatch.setattr(runtime_smoke, "SOURCE_PLUGIN_DIR", canonical)
+    monkeypatch.setattr(runtime_smoke.pi_port, "build", lambda _source, output: _fixture_target(output))
+    monkeypatch.setattr(runtime_smoke, "_executable", lambda name, _env: name)
+    monkeypatch.setenv("PI_PACKAGE_DIR", "/real/pi-packages")
+    calls = []
+    removed = False
+
+    def runner(command, **kwargs):
+        nonlocal removed
+        calls.append((command, kwargs["env"].copy(), kwargs["cwd"], kwargs.get("input")))
+        package = tmp_path / "package"
+        generated = package / "targets/pi"
+        if command[-1] == "--version":
+            output = "0.test\n"
+        elif command[1] == "list":
+            output = "No packages installed.\n" if removed else f"User packages:\n  {package}\n    {package}\n"
+        elif command[1] == "remove":
+            removed = True
+            output = "Removed\n"
+        elif command[1:3] == ["--mode", "rpc"]:
+            records = [] if removed else [
+                {
+                    "name": f"skill:{path.parent.name}",
+                    "source": "skill",
+                    "sourceInfo": {"path": str(path)},
+                }
+                for path in generated.glob("skills/*/SKILL.md")
+            ]
+            output = json.dumps(
+                {
+                    "id": "skills",
+                    "type": "response",
+                    "command": "get_commands",
+                    "success": True,
+                    "data": {"commands": records},
+                }
+            )
+        else:
+            output = "Installed\n"
+        return subprocess.CompletedProcess(command, 0, output, "")
+
+    runtime_smoke.smoke_pi(tmp_path, runner)
+    assert all(call[1]["HOME"] == str(tmp_path / "home") for call in calls)
+    assert all(call[1]["PI_CODING_AGENT_DIR"] == str(tmp_path / "agent") for call in calls)
+    assert all(call[1]["PI_CODING_AGENT_SESSION_DIR"] == str(tmp_path / "sessions") for call in calls)
+    assert all(call[1]["PI_OFFLINE"] == "1" for call in calls)
+    assert all(call[1]["PI_TELEMETRY"] == "0" for call in calls)
+    assert all("PI_PACKAGE_DIR" not in call[1] for call in calls)
+    assert all(call[2] == tmp_path / "workspace" for call in calls)
+    rpc_calls = [call for call in calls if call[0][1:3] == ["--mode", "rpc"]]
+    assert len(rpc_calls) == 2
+    assert all(call[3] == '{"id":"skills","type":"get_commands"}\n' for call in rpc_calls)
+
+
 def test_tree_validation_requires_exact_count_resource_and_executable(tmp_path) -> None:
     target = tmp_path / "target"
     _fixture_target(target)
@@ -218,3 +278,24 @@ def test_resource_validation_detects_mode_drift(tmp_path) -> None:
 
     with pytest.raises(RuntimeError, match="mode differs"):
         runtime_smoke._verify_resource(source / "skills", installed / "skills")
+
+
+def test_pi_resource_validation_requires_the_expected_executable(tmp_path) -> None:
+    source = tmp_path / "source"
+    installed = tmp_path / "installed"
+    source_script = source / runtime_smoke.PI_SOURCE_EXECUTABLE
+    source_script.parent.mkdir(parents=True)
+    source_script.write_text("#!/bin/sh\n")
+    source_script.chmod(0o755)
+    decoy = installed / "other/executable.sh"
+    decoy.parent.mkdir(parents=True)
+    decoy.write_text("#!/bin/sh\n")
+    decoy.chmod(0o755)
+
+    with pytest.raises(RuntimeError, match="installed resource is missing"):
+        runtime_smoke._verify_resource(
+            source,
+            installed,
+            runtime_smoke.PI_SOURCE_EXECUTABLE,
+            runtime_smoke.EXECUTABLE_RESOURCE,
+        )


### PR DESCRIPTION
## Summary

- add `make pi-runtime-smoke` for isolated native Pi package acceptance
- generate a temporary local package and isolate `HOME`, `PI_CODING_AGENT_DIR`, and session state
- disable startup networking/telemetry and use model-free RPC `get_commands`
- verify exact discovery paths for all 51 `/skill:*` commands
- verify the known executable resource byte-for-byte and mode-for-mode
- remove the package and confirm a fresh Pi process no longer discovers it
- update the tested Pi baseline from 0.79.1 to 0.81.1

Continues the remaining runtime hardening tracked in #90.

## Why RPC

Pi 0.81.1 has no standalone skill-list command. Its native RPC `get_commands` request enumerates discovered skill commands and source paths without sending a prompt or making a model call. Built-in or unrelated commands are ignored unless their source path is inside the generated temporary package; generated names and paths must match the exact 51-skill target.

## Isolation

The smoke test uses temporary values for:

- `HOME`
- `PI_CODING_AGENT_DIR`
- `PI_CODING_AGENT_SESSION_DIR`

It also sets `PI_OFFLINE=1`, `PI_SKIP_VERSION_CHECK=1`, and `PI_TELEMETRY=0`, and removes inherited `PI_PACKAGE_DIR`. It never reads or mutates the normal Pi settings, credentials, package cache, or sessions.

## Validation

- `make pi-runtime-smoke` — Pi 0.81.1, 51 skills OK
- `python3 -m pytest scripts/tests/test_runtime_smoke.py -q` — 9 passed
- `make codex-runtime-smoke` — Codex CLI 0.145.0, 51 skills OK
- `make opencode-runtime-smoke` — OpenCode 1.17.2, 51 skills OK
- `make generated-skills-sync` — all four targets and golden snapshots clean
- `make ci` — 204 tests passed; 51 skills and 26 agents evaluated; 77 security components, 0 flagged
