### PR TITLE
test(amp): add isolated runtime smoke harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   pushes, and accidental production Mix commands. The broad Claude hook set,
   async hooks, custom agents, and Tidewave MCP remain deferred.
 
-- **Optional runtime smoke harness** — `make codex-runtime-smoke`,
-  `make pi-runtime-smoke`, and `make opencode-runtime-smoke` validate locally
+- **Optional runtime smoke harness** — `make amp-runtime-smoke`,
+  `make codex-runtime-smoke`, `make pi-runtime-smoke`, and
+  `make opencode-runtime-smoke` validate locally
   generated targets, native installation or discovery, all 51 installed skills,
   retained resources and modes, and fresh-process removal in isolated temporary
   homes without requiring credentials or making model calls.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint lint-fix eval eval-all eval-fix eval-full eval-ci eval-triggers eval-tournament eval-skills eval-agents eval-multimodel eval-compare-models test validate amp-skills amp-skills-sync amp-skills-validate codex-skills codex-skills-sync codex-skills-validate codex-runtime-smoke pi-skills pi-skills-sync pi-skills-validate pi-runtime-smoke opencode-skills opencode-skills-sync opencode-skills-validate opencode-runtime-smoke generated-skills-sync generated-skills-snapshots generated-skills-snapshots-validate security ci clean
+.PHONY: help lint lint-fix eval eval-all eval-fix eval-full eval-ci eval-triggers eval-tournament eval-skills eval-agents eval-multimodel eval-compare-models test validate amp-skills amp-skills-sync amp-skills-validate amp-runtime-smoke codex-skills codex-skills-sync codex-skills-validate codex-runtime-smoke pi-skills pi-skills-sync pi-skills-validate pi-runtime-smoke opencode-skills opencode-skills-sync opencode-skills-validate opencode-runtime-smoke generated-skills-sync generated-skills-snapshots generated-skills-snapshots-validate security ci clean
 
 # Default target
 help: ## Show available commands
@@ -71,6 +71,9 @@ amp-skills-sync: ## Regenerate and verify the committed Amp target
 
 amp-skills-validate: ## Check committed Amp skills for generated drift
 	@python3 -m scripts.build_amp_skills --check
+
+amp-runtime-smoke: ## Optional: smoke-test local target with an isolated Amp runtime
+	@python3 -m scripts.runtime_smoke amp
 
 codex-skills: ## Generate the Codex skills plugin from the canonical Claude plugin
 	@python3 -m scripts.build_codex_skills

--- a/docs/amp.md
+++ b/docs/amp.md
@@ -329,6 +329,20 @@ make validate
 make eval-all
 ```
 
+Maintainers with Amp installed can run a model-free native acceptance check:
+
+```bash
+make amp-runtime-smoke
+```
+
+Tested with Amp `0.0.1784796539-g051498`, this builds the target in a temporary
+directory, installs it with `amp skill add`, verifies exact JSON discovery of
+all 51 skills plus bundled resource bytes and executable modes, removes every
+skill with `amp skill remove`, and confirms a fresh `amp skill list` no longer
+discovers them from any location. Temporary home, XDG, settings, and log paths
+isolate normal user configuration. Update checks and tracing are disabled; an
+unreachable loopback service URL makes unexpected API requests fail closed.
+
 ## Further reading
 
 - [Amp Agent Skills documentation](https://ampcode.com/manual#agent-skills)

--- a/docs/runtime-support.md
+++ b/docs/runtime-support.md
@@ -41,7 +41,7 @@ installation and troubleshooting remain in the linked guides.
 | Deterministic generated target | Canonical source | Yes | Yes | Yes | Yes |
 | Mode-aware CI drift validation | Not applicable | Yes | Yes | Yes | Yes |
 | Golden target snapshot | Not applicable | Yes | Yes | Yes | Yes |
-| Isolated native smoke command | Not applicable | Deferred | Yes | Yes | Yes |
+| Isolated native smoke command | Not applicable | Yes | Yes | Yes | Yes |
 
 “External” Tidewave support means a skill may use Tidewave when the project and
 runtime already expose it. Generated flagship workflows must still complete
@@ -63,9 +63,8 @@ the supported installation and update mechanism. Start a fresh process after
 installing, updating, or removing skills because runtime discovery may be
 cached when a session starts.
 
-The current local acceptance baseline is Codex CLI 0.145.0, Pi 0.81.1, and
-OpenCode 1.17.2. Amp uses standard Agent Skills rather than a repository-pinned
-runtime package version.
+The current local acceptance baseline is Amp 0.0.1784796539-g051498, Codex CLI
+0.145.0, Pi 0.81.1, and OpenCode 1.17.2.
 
 ## Runtime-specific boundaries
 
@@ -120,7 +119,7 @@ Every generated target must pass repository tests that prove:
    changes, and mode-only changes; and
 8. generation does not mutate canonical sources or another runtime target.
 
-The optional Codex, Pi, and OpenCode smoke harnesses additionally verify native
+The optional Amp, Codex, Pi, and OpenCode smoke harnesses additionally verify native
 installation or discovery, all 51 skills, retained resources and executable
 modes, removal behavior, and fresh-process rediscovery. Behavioral acceptance
 uses controlled fixtures and requires `phx-investigate` to reproduce before
@@ -132,6 +131,11 @@ without modifying the fixture.
 Runtime smoke tests must not read, overwrite, or remove a developer's normal
 configuration. Use temporary homes and start a fresh runtime process for each
 discovery boundary.
+
+For Amp, isolate `HOME`, all XDG roots, `AMP_SETTINGS_FILE`, and `AMP_LOG_FILE`.
+The smoke harness disables update checks and tracing, supplies a placeholder API
+key, and uses only local `amp skill` commands. An unreachable loopback `AMP_URL`
+makes any unexpected Amp API request fail closed without using normal credentials.
 
 For Codex, isolate both locations because marketplace metadata and the plugin
 cache use separate roots:

--- a/scripts/runtime_smoke.py
+++ b/scripts/runtime_smoke.py
@@ -13,8 +13,11 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import Callable
+from urllib.parse import unquote, urlparse
+from urllib.request import url2pathname
 
 from scripts.port_lib import SOURCE_PLUGIN_DIR
+from scripts.port_lib import amp as amp_port
 from scripts.port_lib import codex as codex_port
 from scripts.port_lib import opencode as opencode_port
 from scripts.port_lib import pi as pi_port
@@ -94,6 +97,17 @@ def _verify_resource(
         raise RuntimeError(f"installed resource mode differs: {installed_resource}")
 
 
+def _resource_snapshot(path: Path) -> tuple[bytes, int]:
+    return path.read_bytes(), stat.S_IMODE(path.stat().st_mode)
+
+
+def _verify_resource_snapshot(path: Path, expected: tuple[bytes, int]) -> None:
+    if not path.is_file():
+        raise RuntimeError(f"resource is missing: {path}")
+    if _resource_snapshot(path) != expected:
+        raise RuntimeError(f"resource bytes or mode differ: {path}")
+
+
 def _skill_records(records: list[dict], install: Path) -> dict[str, Path]:
     install = install.resolve()
     discovered: dict[str, Path] = {}
@@ -104,6 +118,46 @@ def _skill_records(records: list[dict], install: Path) -> dict[str, Path]:
         name = item.get("name")
         if not isinstance(name, str) or name in discovered:
             raise RuntimeError("OpenCode returned duplicate or invalid generated skills")
+        discovered[name] = location
+    return discovered
+
+
+def _amp_skills(payload: dict) -> list[dict]:
+    if not isinstance(payload, dict):
+        raise RuntimeError("Amp returned invalid skill discovery data")
+    errors = payload.get("errors")
+    records = payload.get("skills")
+    if not isinstance(errors, list) or errors or not isinstance(records, list):
+        raise RuntimeError("Amp returned invalid skill discovery data")
+    if not all(isinstance(item, dict) for item in records):
+        raise RuntimeError("Amp returned an invalid skill record")
+    return records
+
+
+def _amp_skill_names(payload: dict) -> set[str]:
+    names = {item.get("name") for item in _amp_skills(payload)}
+    if not all(isinstance(name, str) and name for name in names):
+        raise RuntimeError("Amp returned an invalid skill name")
+    return names
+
+
+def _amp_skill_records(payload: dict, install: Path) -> dict[str, Path]:
+    records = _amp_skills(payload)
+    install = install.resolve()
+    discovered: dict[str, Path] = {}
+    for item in records:
+        base_dir = item.get("baseDir")
+        if not isinstance(base_dir, str) or not base_dir.startswith("file://"):
+            continue
+        parsed = urlparse(base_dir)
+        if parsed.netloc not in ("", "localhost"):
+            raise RuntimeError(f"Amp returned a non-local skill URI: {base_dir}")
+        location = Path(url2pathname(unquote(parsed.path))).resolve()
+        if not location.is_relative_to(install):
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or name in discovered:
+            raise RuntimeError("Amp returned duplicate or invalid generated skills")
         discovered[name] = location
     return discovered
 
@@ -195,6 +249,105 @@ def smoke_codex(root: Path, runner: Run = subprocess.run) -> None:
     if installed_path.exists():
         raise RuntimeError(f"Codex left the removed plugin on disk: {installed_path}")
     print(f"[runtime-smoke] Codex {version}: {EXPECTED_SKILLS} skills OK")
+
+
+def smoke_amp(root: Path, runner: Run = subprocess.run) -> None:
+    home, workspace = root / "home", root / "workspace"
+    generated = root / "generated-skills"
+    install = workspace / ".agents/skills"
+    xdg_roots = {
+        name: root / name.lower()
+        for name in (
+            "XDG_CONFIG_HOME",
+            "XDG_DATA_HOME",
+            "XDG_CACHE_HOME",
+            "XDG_STATE_HOME",
+        )
+    }
+    for path in (home, workspace, install, *xdg_roots.values()):
+        path.mkdir(parents=True)
+    canonical_resource = SOURCE_PLUGIN_DIR / "skills" / PI_SOURCE_EXECUTABLE
+    canonical_snapshot = _resource_snapshot(canonical_resource)
+    amp_port.build(SOURCE_PLUGIN_DIR, generated)
+    generated_resource = generated / EXECUTABLE_RESOURCE
+    _verify_resource_snapshot(generated_resource, canonical_snapshot)
+    settings = root / "settings.json"
+    settings.write_text(
+        json.dumps(
+            {
+                "amp.experimental.cli.nativeSecretsStorage.enabled": False,
+                "amp.skills.disableClaudeCodeSkills": True,
+                "amp.updates.mode": "disabled",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    for name in tuple(env):
+        if name.startswith(("AMP_", "OTEL_")):
+            env.pop(name)
+    env |= {
+        "HOME": str(home),
+        "AMP_API_KEY": "runtime-smoke-placeholder",
+        "AMP_URL": "http://127.0.0.1:9",
+        "AMP_SKIP_UPDATE_CHECK": "1",
+        "AMP_SETTINGS_FILE": str(settings),
+        "AMP_LOG_FILE": str(root / "amp.log"),
+        **{name: str(path) for name, path in xdg_roots.items()},
+    }
+    executable = _executable("amp", env)
+    version = _run(runner, [executable, "--version"], env, workspace).stdout.strip()
+    if not version:
+        raise RuntimeError("amp returned an empty version")
+    _run(
+        runner,
+        [executable, "skill", "add", str(generated), "--target", str(install)],
+        env,
+        workspace,
+    )
+    _verify_tree(install)
+    _verify_resource_snapshot(generated_resource, canonical_snapshot)
+    _verify_resource_snapshot(install / EXECUTABLE_RESOURCE, canonical_snapshot)
+    expected = {
+        path.parent.name: (install / path.parent.name).resolve()
+        for path in generated.glob("*/SKILL.md")
+    }
+    discovered = _amp_skill_records(
+        json.loads(
+            _run(runner, [executable, "skill", "list", "--json"], env, workspace).stdout
+        ),
+        install,
+    )
+    if discovered != expected:
+        raise RuntimeError(
+            f"Amp discovered {len(discovered)} generated skills, "
+            f"expected the exact {len(expected)}-skill target"
+        )
+    for name in sorted(expected):
+        _run(
+            runner,
+            [executable, "skill", "remove", name, "--target", str(install)],
+            env,
+            workspace,
+        )
+    after = json.loads(
+        _run(runner, [executable, "skill", "list", "--json"], env, workspace).stdout
+    )
+    remaining = _amp_skill_records(after, install)
+    if remaining:
+        raise RuntimeError(f"Amp rediscovered {len(remaining)} generated skills after removal")
+    fallback_names = _amp_skill_names(after) & expected.keys()
+    if fallback_names:
+        raise RuntimeError(
+            f"Amp discovered removed skill names elsewhere: {sorted(fallback_names)}"
+        )
+    if any(install.iterdir()):
+        raise RuntimeError(f"Amp left removed skills on disk: {install}")
+    _verify_tree(generated)
+    _verify_resource_snapshot(generated_resource, canonical_snapshot)
+    _verify_resource_snapshot(canonical_resource, canonical_snapshot)
+    print(f"[runtime-smoke] Amp {version}: {EXPECTED_SKILLS} skills OK")
 
 
 def smoke_pi(root: Path, runner: Run = subprocess.run) -> None:
@@ -302,13 +455,16 @@ def smoke_opencode(root: Path, runner: Run = subprocess.run) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("runtime", choices=("codex", "pi", "opencode"))
+    parser.add_argument("runtime", choices=("amp", "codex", "pi", "opencode"))
     args = parser.parse_args()
     try:
         with tempfile.TemporaryDirectory(prefix=f"{args.runtime}-runtime-smoke-") as temporary:
-            {"codex": smoke_codex, "pi": smoke_pi, "opencode": smoke_opencode}[
-                args.runtime
-            ](Path(temporary))
+            {
+                "amp": smoke_amp,
+                "codex": smoke_codex,
+                "pi": smoke_pi,
+                "opencode": smoke_opencode,
+            }[args.runtime](Path(temporary))
     except (KeyError, OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
         print(f"[runtime-smoke] FAIL: {error}", file=sys.stderr)
         return 1

--- a/scripts/tests/test_runtime_smoke.py
+++ b/scripts/tests/test_runtime_smoke.py
@@ -22,6 +22,137 @@ def _fixture_target(output: Path) -> None:
     resource.chmod(0o755)
 
 
+def test_amp_uses_native_install_exact_discovery_and_fresh_removal(tmp_path, monkeypatch) -> None:
+    canonical = tmp_path / "canonical"
+    canonical_resource = canonical / "skills" / runtime_smoke.PI_SOURCE_EXECUTABLE
+    canonical_resource.parent.mkdir(parents=True)
+    canonical_resource.write_text("#!/bin/sh\n")
+    canonical_resource.chmod(0o755)
+
+    def build_amp_fixture(_source, output):
+        _fixture_target(output)
+        nested = output / "skills"
+        for skill in nested.iterdir():
+            skill.rename(output / skill.name)
+        nested.rmdir()
+
+    monkeypatch.setattr(runtime_smoke, "SOURCE_PLUGIN_DIR", canonical)
+    monkeypatch.setattr(
+        runtime_smoke.amp_port,
+        "build",
+        build_amp_fixture,
+    )
+    monkeypatch.setattr(runtime_smoke, "_executable", lambda name, _env: name)
+    for name in (
+        "AMP_API_KEY",
+        "AMP_ENABLE_TRACING",
+        "AMP_HOME",
+        "AMP_PWD",
+        "AMP_SETTINGS_FILE",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+    ):
+        monkeypatch.setenv(name, f"real-{name.lower()}")
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/real/config")
+    calls = []
+
+    def runner(command, **kwargs):
+        calls.append((command, kwargs["env"].copy(), kwargs["cwd"]))
+        install = tmp_path / "workspace/.agents/skills"
+        generated = tmp_path / "generated-skills"
+        if command[-1] == "--version":
+            output = "amp test\n"
+        elif command[1:3] == ["skill", "add"]:
+            for skill in generated.iterdir():
+                shutil.copytree(skill, install / skill.name, copy_function=shutil.copy2)
+            output = "Installed\n"
+        elif command[1:3] == ["skill", "remove"]:
+            shutil.rmtree(install / command[3])
+            output = "Removed\n"
+        else:
+            records = [
+                {
+                    "name": path.name,
+                    "baseDir": path.resolve().as_uri(),
+                }
+                for path in install.iterdir()
+                if path.is_dir()
+            ]
+            output = json.dumps({"skills": records, "errors": []})
+        return subprocess.CompletedProcess(command, 0, output, "")
+
+    runtime_smoke.smoke_amp(tmp_path, runner)
+    assert all(call[1]["HOME"] == str(tmp_path / "home") for call in calls)
+    assert all(call[1]["AMP_SETTINGS_FILE"] == str(tmp_path / "settings.json") for call in calls)
+    assert all(call[1]["AMP_LOG_FILE"] == str(tmp_path / "amp.log") for call in calls)
+    assert all(call[1]["AMP_API_KEY"] == "runtime-smoke-placeholder" for call in calls)
+    assert all(call[1]["AMP_URL"] == "http://127.0.0.1:9" for call in calls)
+    assert all(call[1]["AMP_SKIP_UPDATE_CHECK"] == "1" for call in calls)
+    assert all("AMP_ENABLE_TRACING" not in call[1] for call in calls)
+    assert all("AMP_HOME" not in call[1] for call in calls)
+    assert all("AMP_PWD" not in call[1] for call in calls)
+    assert all("OTEL_EXPORTER_OTLP_ENDPOINT" not in call[1] for call in calls)
+    assert all(call[1]["XDG_CONFIG_HOME"] == str(tmp_path / "xdg_config_home") for call in calls)
+    assert all(call[2] == tmp_path / "workspace" for call in calls)
+    assert sum(call[0][1:4] == ["skill", "list", "--json"] for call in calls) == 2
+    assert sum(call[0][1:3] == ["skill", "remove"] for call in calls) == 51
+
+
+def test_amp_records_require_unique_names_clean_payload_and_path_boundaries(tmp_path) -> None:
+    install = tmp_path / "skills"
+    expected = install / "phx-review"
+    expected.mkdir(parents=True)
+    sibling = tmp_path / "skills-other/false"
+    sibling.mkdir(parents=True)
+    records = [
+        {"name": "phx-review", "baseDir": expected.resolve().as_uri()},
+        {"name": "false", "baseDir": sibling.resolve().as_uri()},
+        {"name": "built-in", "baseDir": "builtin:///skills"},
+    ]
+    assert runtime_smoke._amp_skill_records(
+        {"skills": records, "errors": []}, install
+    ) == {"phx-review": expected.resolve()}
+    with pytest.raises(RuntimeError, match="duplicate"):
+        runtime_smoke._amp_skill_records(
+            {"skills": [records[0], records[0]], "errors": []}, install
+        )
+    with pytest.raises(RuntimeError, match="invalid skill discovery"):
+        runtime_smoke._amp_skill_records(
+            {"skills": records, "errors": ["broken skill"]}, install
+        )
+    with pytest.raises(RuntimeError, match="non-local skill URI"):
+        runtime_smoke._amp_skill_records(
+            {
+                "skills": [
+                    {"name": "false", "baseDir": "file://remote.example/skills/false"}
+                ],
+                "errors": [],
+            },
+            install,
+        )
+    fallback = {
+        "skills": [
+            {
+                "name": "phx-review",
+                "baseDir": (tmp_path / "global/phx-review").resolve().as_uri(),
+            }
+        ],
+        "errors": [],
+    }
+    assert runtime_smoke._amp_skill_names(fallback) & {"phx-review"} == {
+        "phx-review"
+    }
+
+
+def test_resource_snapshot_detects_source_mutation(tmp_path) -> None:
+    resource = tmp_path / "watch-pr.sh"
+    resource.write_text("#!/bin/sh\n")
+    resource.chmod(0o755)
+    snapshot = runtime_smoke._resource_snapshot(resource)
+    resource.write_text("#!/bin/sh\necho mutated\n")
+    with pytest.raises(RuntimeError, match="bytes or mode differ"):
+        runtime_smoke._verify_resource_snapshot(resource, snapshot)
+
+
 def test_codex_uses_isolated_homes_native_install_and_fresh_removal(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(runtime_smoke.codex_port, "build", lambda _source, output: _fixture_target(output))
     monkeypatch.setattr(runtime_smoke, "_executable", lambda name, _env: name)


### PR DESCRIPTION
## Summary

- add `make amp-runtime-smoke` for native, model-free Amp acceptance
- build the current 51-skill target in a temporary directory, install it with `amp skill add`, and verify exact `amp skill list --json` names and paths
- verify the known bundled executable against an immutable canonical byte/mode snapshot before and after installation/removal
- remove every skill with native `amp skill remove` and reject both residual files and same-name fallback discovery from another location
- isolate `HOME`, all XDG roots, settings, logs, Amp/OTel environment, updates, tracing, credentials, and API traffic
- record the tested Amp version and close the final runtime-smoke gap in the support matrix

## Why

Codex, Pi, and OpenCode already have isolated runtime smoke commands. Amp was the remaining generated target whose acceptance stopped at deterministic generation and manual installation guidance. The current Amp CLI exposes local `skill add`, JSON `skill list`, and `skill remove`, so exact native discovery and removal can now be tested without a model call or a real account.

## Tested

- Amp `0.0.1784796539-g051498`
- `make amp-runtime-smoke` — 51 exact skills discovered, resource bytes/mode preserved, native removal confirmed
- `make codex-runtime-smoke` — Codex CLI 0.145.0, 51 skills
- `make pi-runtime-smoke` — Pi 0.81.1, 51 skills
- `make opencode-runtime-smoke` — OpenCode 1.17.2, 51 skills
- `make generated-skills-sync` — all targets drift-clean; golden snapshots unchanged
- `make ci` — 207 tests; 51 skills and 26 agents evaluated; 77 security components, 0 flagged
- focused runtime smoke tests — 12 passed

## Isolation notes

The Amp harness uses a placeholder API key and unreachable loopback `AMP_URL`, disables update checks and tracing, removes inherited `AMP_*`/`OTEL_*` state, and redirects user/XDG/settings/log paths into the temporary root. Any unexpected Amp API request fails closed rather than using normal credentials.

Closes the Amp smoke-harness workstream in #90.