### PR TITLE
docs(port): clarify runtime install lifecycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Generated-runtime install lifecycle guidance** — Amp now documents native,
+  target-scoped removal and exact-sync boundaries; Pi distinguishes configured
+  Git refs from unpinned dependencies and includes both project and user clean
+  reinstall flows; OpenCode uses its documented plural skills path and treats
+  slash invocation as a tested 1.17.2 convenience rather than the portable API.
+
 - **Codex plugin skill references now use their required runtime namespace** —
   explicit invocations and generated sibling references use
   `$elixir-phoenix:phx-investigate` rather than the non-resolving unqualified

--- a/README.md
+++ b/README.md
@@ -262,8 +262,10 @@ git clone --filter=blob:none --sparse https://github.com/oliver-kriska/claude-el
 git -C .opencode/skills/elixir-phoenix sparse-checkout set targets/opencode
 ```
 
-Start a fresh session, then use `/phx-investigate`, `/phx-review`, or explicitly
-say “Use the skill tool to load the phx-investigate skill, then …”. OpenCode
+Start a fresh session and explicitly say “Use the skill tool to load the
+phx-investigate skill, then …”. Tested OpenCode 1.17.2 also accepts
+`/phx-investigate` and `/phx-review`, but the skill tool is the documented
+portable interface. OpenCode
 selects the model implicitly. This target contains skills and complete bundled
 resources only—not hooks, custom agents, or Tidewave MCP configuration. The two
 flagship workflows are explicitly adapted; some other skills may still describe

--- a/docs/amp.md
+++ b/docs/amp.md
@@ -223,6 +223,23 @@ For a global installation, apply the same rule under
 `~/.config/agents/skills/`; that directory may contain unrelated skills, so do
 not delete it wholesale unless it contains nothing else.
 
+Amp also provides native removal for one known skill at a time:
+
+```bash
+# Project-local
+amp skill remove phx-review --target "$PWD/.agents/skills"
+
+# Global (skill remove has no --global flag)
+amp skill remove phx-review --target "$HOME/.config/agents/skills"
+```
+
+Repeat that command only for names installed by this package. A clean reinstall
+removes every known package-owned skill, reruns `amp skill add`, and starts a
+fresh Amp process. Do not loop over every directory in a shared skills root;
+that can remove unrelated project or personal skills. `--overwrite` is the
+normal update path, but removal followed by installation is the exact-sync path
+when a release deletes or renames a skill.
+
 ## Feature compatibility
 
 | Capability | Claude Code plugin | Amp edition |

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -3,8 +3,8 @@
 This generated skills-only baseline is tested with OpenCode 1.17.2. Runtime
 acceptance used `opencode/north-mini-code-free`; skill behavior still depends on
 the model selected by each user. OpenCode recursively discovers `SKILL.md` files
-below `.opencode/skill/` and `.opencode/skills/` (and the equivalent global
-config roots). It does not provide a native Git or package installer for skills,
+below the documented `.opencode/skills/` project path and equivalent global
+config root. It does not provide a native Git or package installer for skills,
 so installation is a sparse Git checkout.
 
 See the [runtime support matrix](runtime-support.md) for a concise comparison
@@ -32,11 +32,11 @@ git clone --filter=blob:none --sparse \
 git -C ~/.config/opencode/skills/elixir-phoenix sparse-checkout set targets/opencode
 ```
 
-After this feature merges, both commands use the default `main` branch. Reviewers
-can test this branch before merge by adding the branch to `git clone`:
+Both commands use the default `main` branch. Reviewers can test a feature branch
+or tag before merge by adding its ref to `git clone`:
 
 ```bash
-git clone --branch feat/opencode-skills-package --filter=blob:none --sparse \
+git clone --branch <branch-or-tag> --filter=blob:none --sparse \
   https://github.com/oliver-kriska/claude-elixir-phoenix.git \
   .opencode/skills/elixir-phoenix
 git -C .opencode/skills/elixir-phoenix sparse-checkout set targets/opencode
@@ -48,8 +48,8 @@ OpenCode project and may influence model-driven skill selection there.
 
 ## Use
 
-The flagship generated records are `/phx-investigate` and `/phx-review`.
-OpenCode may select a skill from its description, but the most reliable explicit
+The flagship generated skill names are `phx-investigate` and `phx-review`.
+OpenCode may select a skill from its description, but the documented explicit
 prompt is:
 
 ```text
@@ -63,7 +63,8 @@ resources are copied byte-for-byte.
 
 This is a focused baseline, not full Claude Code parity. It does not install
 hooks, custom agents, separate command definitions, MCP servers, AGENTS.md, or
-configuration. OpenCode itself exposes discovered skills as slash commands.
+configuration. OpenCode 1.17.2 also exposes discovered skills as slash commands;
+the documented skill-tool prompt above is the portable explicit invocation.
 Native OpenCode subagents are an optional optimization in the flagship
 workflows, and the sequential fallback is valid. Tidewave is optional and its
 MCP setup is deferred. Exact Claude colon syntax such as `/phx:review` is not

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -62,15 +62,26 @@ Update the installed Git package:
 pi update git:github.com/oliver-kriska/claude-elixir-phoenix
 ```
 
-A pinned branch remains on that branch and advances when the package is updated.
-Tags and commit hashes remain fixed. Run `pi install ...@new-ref` to switch refs.
+Pi treats every explicit `@ref` as pinned to that configured ref name. Updating
+reconciles the checkout to that same ref; a moving branch name can therefore
+resolve to a newer commit, while a tag or commit SHA normally remains fixed.
+Pi does not model branch names as unpinned dependencies. Run
+`pi install ...@new-ref` to deliberately change the configured ref.
 Remove the user-level package with:
 
 ```bash
 pi remove git:github.com/oliver-kriska/claude-elixir-phoenix
 ```
 
-For a project-local package, pass `-l` to `pi remove` from that project.
+For a project-local package, remove it from that project with the same trust
+boundary used during installation:
+
+```bash
+pi remove -l git:github.com/oliver-kriska/claude-elixir-phoenix --approve
+```
+
+`--approve` is required only when project trust has not already been persisted.
+Start a fresh Pi process after an install, update, ref change, or removal.
 
 ## Supported capabilities
 
@@ -119,12 +130,22 @@ pi list
 ```
 
 If skills do not appear, start a fresh session and confirm skill commands were
-not disabled in Pi settings. A clean reinstall is:
+not disabled in Pi settings. A clean user-level reinstall is:
 
 ```bash
 pi remove git:github.com/oliver-kriska/claude-elixir-phoenix
 pi install git:github.com/oliver-kriska/claude-elixir-phoenix
 ```
+
+For a project-local clean reinstall, run from that project:
+
+```bash
+pi remove -l git:github.com/oliver-kriska/claude-elixir-phoenix --approve
+pi install -l git:github.com/oliver-kriska/claude-elixir-phoenix --approve
+```
+
+For non-interactive Git-backed updates, set `GIT_TERMINAL_PROMPT=0` so missing
+credentials fail instead of waiting for a prompt.
 
 The generated package manifest deliberately declares `pi.skills` as an array.
 Pi 0.81.1 expects resource values to be arrays; a string can prevent package

--- a/docs/runtime-support.md
+++ b/docs/runtime-support.md
@@ -55,13 +55,18 @@ without Tidewave, named custom agents, or Claude-only task APIs.
 | Amp | Command palette → `skill: invoke`, or explicitly request the skill in the prompt | Direct GitHub Agent Skills install | [Amp guide](amp.md) |
 | Codex | `$elixir-phoenix:phx-investigate`, `$elixir-phoenix:phx-review` | Native Codex Git marketplace plugin | [Codex guide](codex.md) |
 | Pi | `/skill:phx-investigate`, `/skill:phx-review` | Native Pi Git package | [Pi guide](pi.md) |
-| OpenCode | `/phx-investigate`, `/phx-review`, or ask the skill tool to load the skill | Sparse Git checkout | [OpenCode guide](opencode.md) |
+| OpenCode | Ask the skill tool to load the skill; 1.17.2 also accepts `/phx-investigate` and `/phx-review` | Sparse Git checkout | [OpenCode guide](opencode.md) |
 
 Codex plugin skills are qualified by the plugin manifest name. OpenCode 1.17.2
 does not provide a native Git skills-package installer, so a sparse checkout is
 the supported installation and update mechanism. Start a fresh process after
 installing, updating, or removing skills because runtime discovery may be
 cached when a session starts.
+
+The same lifecycle boundary applies to every generated runtime: install,
+update, clean reinstall, ref change, and uninstall affect newly started
+processes. Standalone list/debug commands are already fresh processes; they do
+not refresh the catalog of an existing interactive session.
 
 The current local acceptance baseline is Amp 0.0.1784796539-g051498, Codex CLI
 0.145.0, Pi 0.81.1, and OpenCode 1.17.2.


### PR DESCRIPTION
## Summary

- document native Amp removal without risking unrelated skills in shared roots, and distinguish overwrite updates from exact clean synchronization
- clarify Pi's source-verified Git-ref semantics and add exact trusted project-local remove/reinstall commands
- document the fresh-process boundary for install, update, ref changes, clean reinstall, and uninstall on every generated runtime
- use OpenCode's documented plural skills path and distinguish its portable skill-tool invocation from version-tested 1.17.2 slash convenience
- remove stale pre-merge OpenCode branch wording

## Why

After adding native smoke coverage for all four generated runtimes, I audited install, update, clean reinstall, and uninstall commands against the installed CLIs and current authoritative docs/source. The generated targets are healthy, but lifecycle documentation had three gaps:

1. Amp exposes native `skill remove`, while our guide described only manual deletion.
2. Pi models every explicit `@ref` as pinned to the configured ref name; update reconciles that name rather than treating branches as a separate unpinned dependency type.
3. OpenCode's primary docs specify `.opencode/skills/` and the skill tool; slash commands remain useful but are a tested 1.17.2 convenience.

## Evidence

- Amp `0.0.1784796539-g051498`: `skill add/list/remove --help` and isolated native smoke
- Codex CLI `0.145.0`: plugin marketplace/add/remove/update lifecycle rechecked; no correction required
- Pi `0.81.1`: CLI help plus current `packages/coding-agent/src/utils/git.ts`, `package-manager.ts`, and package docs
- OpenCode `1.17.2`: `debug skill --pure` plus current official skills documentation

## Validation

- `make lint`
- `make generated-skills-sync`
- generated target diff remains empty; golden snapshots unchanged

## History

This clean-main replacement supersedes automatically closed stacked PR #106 and conflicting replacement #107. The reviewed documentation patch is unchanged.

Updates the lifecycle-audit workstream in #90.
