### PR TITLE
docs: correct post-runtime support claims

### DIFF
--- a/.claude/skills/cc-changelog/references/analysis-rules.md
+++ b/.claude/skills/cc-changelog/references/analysis-rules.md
@@ -20,7 +20,7 @@ When analyzing CC changelog entries, map them to specific plugin components:
 
 | CC Change Pattern | Plugin Files to Check |
 |-------------------|-----------------------|
-| New frontmatter fields | All 25 agents in `plugins/elixir-phoenix/agents/*.md` |
+| New frontmatter fields | All 26 agents in `plugins/elixir-phoenix/agents/*.md` |
 | `model:` value changes | Agents using specific model values |
 | `permissionMode:` changes | All agents (all use `bypassPermissions`) |
 | `effort:` level changes | All agents with effort levels |
@@ -75,6 +75,7 @@ When analyzing CC changelog entries, map them to specific plugin components:
 ### BREAKING — Requires Immediate Action
 
 Flag as BREAKING when CC changelog says:
+
 - "Breaking change" explicitly
 - "Removed" a feature/parameter we use
 - "Changed" behavior of a hook event we rely on
@@ -86,6 +87,7 @@ Flag as BREAKING when CC changelog says:
 ### OPPORTUNITY — New Feature We Could Use
 
 Flag as OPPORTUNITY when:
+
 - New hook event added (check "Available but NOT used" list in memory)
 - New agent frontmatter field that could improve our agents
 - New plugin capability (`userConfig`, new `${}` variables)
@@ -97,6 +99,7 @@ Flag as OPPORTUNITY when:
 ### RELEVANT FIX — CC Fixed Something We Workaround
 
 Flag as RELEVANT FIX when:
+
 - CC fixed a bug we documented in memory or CLAUDE.md
 - CC fixed a behavior our hooks explicitly handle
 - Error mentioned in our compound solutions
@@ -106,6 +109,7 @@ Flag as RELEVANT FIX when:
 ### DEPRECATION — Migration Needed
 
 Flag as DEPRECATION when:
+
 - CC deprecated a tool/parameter we use
 - CC will remove something in a future version
 - CC recommends migrating from X to Y (and we use X)
@@ -135,6 +139,7 @@ After analysis, update `reference_cc_source_internals.md` with:
 ```
 
 Add new sections for:
+
 - New hook events → "Available but NOT used" list
 - New agent frontmatter → Agent Frontmatter section
 - New plugin capabilities → Plugin Capabilities section

--- a/.claude/skills/plugin-dev-workflow/SKILL.md
+++ b/.claude/skills/plugin-dev-workflow/SKILL.md
@@ -15,9 +15,9 @@ Run `make help` to see all available commands:
 
 ```bash
 make eval          # Quick: lint + score changed skills/agents
-make eval-all      # Full: all 50 skills + 25 agents
+make eval-all      # Full: all 51 skills + 26 agents
 make eval-fix      # Auto-fix + show failures
-make test          # 75 pytest tests for eval framework
+make test          # 207 pytest tests for eval framework and port tooling
 make ci            # Full CI pipeline
 ```
 
@@ -77,7 +77,7 @@ make ci            # Full CI pipeline
 ## When Editing Eval Framework (lab/eval/*.py)
 
 1. Make your changes
-2. Run `make test` — 75 pytest tests must pass
+2. Run `make test` — all pytest tests must pass
 3. Run `make eval-all` — verify no skills/agents regressed
 4. If adding new matchers: add tests in `lab/eval/tests/test_matchers.py`
 

--- a/.claude/skills/promote/references/templates.md
+++ b/.claude/skills/promote/references/templates.md
@@ -34,6 +34,7 @@ Use Unicode box-drawing characters for a polished look. Every line must be **exa
 ### Column widths
 
 The table area between `╞` borders has 3 columns:
+
 - Col 1 (Change): 35 chars
 - Col 2 (Before): 10 chars
 - Col 3 (After): 23 chars
@@ -110,7 +111,10 @@ Best used opportunistically, not for every release.
 
 ### Pattern E: Long-Form (v2.6.0 — 150 likes, best overall)
 
-**7-9 tweets** covering a major milestone. Data-heavy throughout. Works when the content is genuinely excellent (self-improving skills, 0/8 → 8/8 eval scores). Risk: longer threads lose casual readers. Only use for truly big releases.
+**7-9 tweets** covering a major milestone. Data-heavy throughout. Works when
+the content is genuinely excellent (self-improving skills, 0/8 → 8/8 eval
+scores). Risk: longer threads lose casual readers. Only use for truly big
+releases.
 
 ## Top-Performing Elements (from analytics)
 
@@ -120,7 +124,7 @@ Best used opportunistically, not for every release.
 | Concrete numbers | High trust signal | "32/40 descriptions rewritten under 200 chars" |
 | Real incident stories | High bookmarks | "72k+ orphaned jobs before someone caught it" |
 | Transparent methodology | Builds authority | "Validated across 75 real sessions" |
-| Eval scores | Credibility closer | "All 50 skills pass eval (avg 0.988)" |
+| Eval scores | Credibility closer | "All 51 skills pass eval (avg 0.986)" |
 
 ## Anti-Patterns (from analytics)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **Canonical multi-runtime support matrix** — documents native invocation,
   distribution, supported and deferred capabilities, generated-target
-  acceptance requirements, and isolated Codex/OpenCode smoke-test contracts.
+  acceptance requirements, and isolated Amp, Codex, Pi, and OpenCode smoke-test
+  contracts.
 
 - **All-runtime generated skills sync command** — contributors can run
   `make generated-skills-sync` to regenerate and validate Amp, Codex, Pi, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,7 +370,7 @@ npm install  # Pre-commit hooks + linting
 make help          # Show all commands
 make lint          # Lint markdown
 make lint-fix      # Auto-fix lint
-make test          # 75 pytest tests for eval framework
+make test          # 207 pytest tests for eval framework and port tooling
 make eval          # Quick: lint + score changed skills/agents + trigger accuracy (cached)
 make eval-all      # Score all 51 skills + 26 agents + trigger accuracy
 make eval-fix      # Auto-fix lint + show failures + suggest autoresearch

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ lint-fix: ## Auto-fix markdown lint errors
 eval: ## Quick: lint + score changed skills/agents only
 	@bash lab/eval/run_eval.sh --changed
 
-eval-all: ## Score all 50 skills + 25 agents (structural)
+eval-all: ## Score all 51 skills + 26 agents (structural)
 	@bash lab/eval/run_eval.sh --all
 
 eval-fix: ## Auto-fix lint + show failures + suggest autoresearch command

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ workflows. See [Use with Pi](#use-with-pi); extensions, prompt templates, MCP,
 and custom agents are intentionally not included yet.
 
 **Using OpenCode?** Install the generated skills-only target for all 51 skills,
-including `/phx-investigate` and `/phx-review`. See
-[Use with OpenCode](#use-with-opencode) and the [OpenCode guide](docs/opencode.md).
+including `phx-investigate` and `phx-review`. In the tested OpenCode 1.17.2 setup,
+they are also available as `/phx-investigate` and `/phx-review`; the skill tool
+is the portable explicit interface. See [Use with OpenCode](#use-with-opencode) and the
+[OpenCode guide](docs/opencode.md).
 
 Compare native invocation, installation, and deliberately deferred capabilities
 in the canonical [runtime support matrix](docs/runtime-support.md). Generated
@@ -61,8 +63,8 @@ that prevent the mistakes Elixir developers actually make in production.
 │  ⚗  Elixir/Phoenix Plugin for Claude Code                           │
 │                                                                     │
 │  ┌──────────┬──────────┬──────────┬──────────┬──────────┐           │
-│  │    26    │    51    │   139    │    31    │    26    │           │
-│  │  Agents  │  Skills  │   Refs   │  Hooks   │Iron Laws │           │
+│  │    26    │    51    │   140    │    30    │    26    │           │
+│  │  Agents  │  Skills  │   Refs   │Hook Regs │Iron Laws │           │
 │  └──────────┴──────────┴──────────┴──────────┴──────────┘           │
 │                                                                     │
 │  AGENTS                          COMMANDS                           │
@@ -263,13 +265,14 @@ git -C .opencode/skills/elixir-phoenix sparse-checkout set targets/opencode
 ```
 
 Start a fresh session and explicitly say “Use the skill tool to load the
-phx-investigate skill, then …”. Tested OpenCode 1.17.2 also accepts
-`/phx-investigate` and `/phx-review`, but the skill tool is the documented
-portable interface. OpenCode
+phx-investigate skill, then …”. In the tested OpenCode 1.17.2 setup,
+`/phx-investigate` and `/phx-review` also work when they do not collide with
+existing commands, but the skill tool is the documented portable interface. OpenCode
 selects the model implicitly. This target contains skills and complete bundled
-resources only—not hooks, custom agents, or Tidewave MCP configuration. The two
-flagship workflows are explicitly adapted; some other skills may still describe
-optional Claude-specific orchestration APIs. See the [OpenCode installation and
+resources only—not hooks, custom agents, or Tidewave MCP configuration.
+Investigation, review, plan, work, PR-review, and full-lifecycle workflows are
+explicitly adapted; some other skills may still describe optional
+Claude-specific orchestration APIs. See the [OpenCode installation and
 support guide](docs/opencode.md) for global setup, updates, uninstall,
 feature-branch review, discovery debugging, and limitations.
 
@@ -795,10 +798,10 @@ This plugin runs skills, agents, and hooks inside Claude Code with your tool
 permissions, so it ships a verifiable security posture:
 
 - **Independently scanned** with [NVIDIA SkillSpector](https://github.com/NVIDIA/SkillSpector)
-  (static analysis, **zero data egress**): **65 / 75 components SAFE**, 6 CAUTION,
+  (static analysis, **zero data egress**): **66 / 77 components SAFE**, 7 CAUTION,
   4 DO_NOT_INSTALL raw. The four DO_NOT_INSTALL components are documented false
   positives with reviewed baselines, so **after baselines 0 remain and the scan
-  gate passes** (the 6 CAUTION-tier components stay documented). A static scanner
+  gate passes** (the 7 CAUTION-tier components stay documented). A static scanner
   flags the *safety-enforcing* and *security-auditing* skills precisely because
   they name dangerous patterns in order to forbid or detect them (e.g. the line
   literally reads `NEVER bypass security checks for speed`).
@@ -821,7 +824,7 @@ make help             # Show all available commands
 make eval             # Quick: lint + score changed skills/agents only
 make eval-all         # Full structural: all 51 skills + all 26 agents
 make eval-fix         # Auto-fix lint + show failures + suggest autoresearch
-make test             # 75 pytest tests for eval framework
+make test             # 207 pytest tests for eval framework and port tooling
 make generated-skills-sync # Regenerate and verify all four runtime targets
 make ci               # Full CI: lint + test + validate + eval + security (same as GitHub Actions)
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ machine — no skill or agent content leaves the local process.
 
 ```bash
 pipx install --python python3.13 "git+https://github.com/NVIDIA/skillspector.git"
-lab/skillspector/scan.sh        # scans all 75 components, exit 0 = clean
+lab/skillspector/scan.sh        # scans all 77; exit 0 = baseline-aware gate passes
 ```
 
 Or scan any single component directly:
@@ -30,12 +30,12 @@ skillspector scan plugins/elixir-phoenix/skills/work/ --no-llm
 
 ## Results
 
-Scanned with SkillSpector v2.x, static analysis only:
+Raw results without reviewed baselines, using SkillSpector v2.x static analysis:
 
 | Tier | Skills | Agents | Total |
 |------|-------:|-------:|------:|
-| SAFE (score 0–20)     | 42 | 23 | **65 / 75** |
-| CAUTION (21–50)       |  5 |  1 |  6 |
+| SAFE (score 0–20)     | 42 | 24 | **66 / 77** |
+| CAUTION (21–50)       |  6 |  1 |  7 |
 | DO_NOT_INSTALL (51+)  |  3 |  1 |  4 |
 
 The 4 `DO_NOT_INSTALL` components are **documented false positives** — the scanner
@@ -43,7 +43,7 @@ is a static regex/AST tool, so it's negation-blind and context-blind: it matches
 a dangerous keyword without seeing the prohibition or detection-context around
 it. Each is recorded in a reviewed baseline under
 [`lab/skillspector/baselines/`](lab/skillspector/baselines/); after baselines
-**0 `DO_NOT_INSTALL` findings remain and the scan gate passes (exit 0)**. The 6
+**the repository scan reports 0 components flagged and exits 0**. The 7
 `CAUTION`-tier components (scores 21–32, all below the 51 `DO_NOT_INSTALL`
 threshold) stay `CAUTION` and are not baselined — they are documented below.
 
@@ -64,7 +64,7 @@ to forbid or find them.
 
 ### CAUTION-tier components (not baselined)
 
-Six components land in the `CAUTION` band (21–50). They are left un-baselined —
+Seven components land in the `CAUTION` band (21–50). They are left un-baselined —
 none crosses the `DO_NOT_INSTALL` threshold — and each is a benign artifact of
 the plugin's own workflow design:
 
@@ -76,10 +76,12 @@ the plugin's own workflow design:
 | `skills/brief` | 21 | AS1 agent-config access | Reads `.claude/plans/{slug}/plan.md` to explain a plan. |
 | `skills/compound` | 21 | RA1 self-modification | Writes solution docs into `.claude/solutions/`. |
 | `skills/recall` | 21 | AS1 agent-config access | Reads `.claude/solutions/` and past-session paths for archaeology. |
+| `skills/learn-from-fix` | 21 | AS1 agent-config access | Reads project and user Claude guidance to identify and persist a corrected convention. |
 
-The shared trigger is that these skills legitimately read and write the plugin's
-own `.claude/` artifact directories — the very state machine the workflow runs
-on — which the scanner flags as generic "agent config directory access."
+The six skill entries legitimately read or write the plugin's own `.claude/`
+artifacts, which the scanner treats as generic agent-config access or
+self-modification. The agent entry has the separate anti-refusal match shown in
+the table.
 
 ## What this plugin does and doesn't do
 

--- a/docs/amp.md
+++ b/docs/amp.md
@@ -352,10 +352,11 @@ Maintainers with Amp installed can run a model-free native acceptance check:
 make amp-runtime-smoke
 ```
 
-Tested with Amp `0.0.1784796539-g051498`, this builds the target in a temporary
-directory, installs it with `amp skill add`, verifies exact JSON discovery of
-all 51 skills plus bundled resource bytes and executable modes, removes every
-skill with `amp skill remove`, and confirms a fresh `amp skill list` no longer
+The acceptance run recorded on 2026-07-23 used Amp
+`0.0.1784809706-g96cc8a`. It builds the target in a temporary directory,
+installs it with `amp skill add`, verifies exact JSON discovery of all 51 skills
+plus bundled resource bytes and executable modes, removes every skill with
+`amp skill remove`, and confirms a fresh `amp skill list` no longer
 discovers them from any location. Temporary home, XDG, settings, and log paths
 isolate normal user configuration. Update checks and tracing are disabled; an
 unreachable loopback service URL makes unexpected API requests fail closed.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -38,14 +38,14 @@ Start a fresh Codex session after installation. The marketplace entry resolves
 testing uses the target committed on the requested ref rather than silently
 falling back to `main`.
 
-To test a feature branch before merge:
+To test a feature branch or tag before merge:
 
 ```bash
 codex plugin remove elixir-phoenix@oliver-kriska 2>/dev/null || true
 codex plugin marketplace remove oliver-kriska 2>/dev/null || true
 codex plugin marketplace add \
   oliver-kriska/claude-elixir-phoenix \
-  --ref feat/codex-skills-plugin
+  --ref <branch-or-tag>
 codex plugin add elixir-phoenix@oliver-kriska
 ```
 

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -5,7 +5,9 @@ acceptance used `opencode/north-mini-code-free`; skill behavior still depends on
 the model selected by each user. OpenCode recursively discovers `SKILL.md` files
 below the documented `.opencode/skills/` project path and equivalent global
 config root. It does not provide a native Git or package installer for skills,
-so installation is a sparse Git checkout.
+so installation is a sparse Git checkout. The nested checkout layout relies on
+recursive discovery verified with OpenCode 1.17.2; the documented portable
+layout places each skill directly under `.opencode/skills/`.
 
 See the [runtime support matrix](runtime-support.md) for a concise comparison
 with Claude Code, Amp, Codex, and Pi.
@@ -63,8 +65,9 @@ resources are copied byte-for-byte.
 
 This is a focused baseline, not full Claude Code parity. It does not install
 hooks, custom agents, separate command definitions, MCP servers, AGENTS.md, or
-configuration. OpenCode 1.17.2 also exposes discovered skills as slash commands;
-the documented skill-tool prompt above is the portable explicit invocation.
+configuration. OpenCode 1.17.2 also projects discovered skills as slash commands
+when their names do not collide with existing commands; the documented
+skill-tool prompt above is the portable explicit invocation.
 Native OpenCode subagents are an optional optimization in the flagship
 workflows, and the sequential fallback is valid. Tidewave is optional and its
 MCP setup is deferred. Exact Claude colon syntax such as `/phx:review` is not

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -27,10 +27,10 @@ Pi clones Git packages into its package cache. Start a fresh session after
 installation. The repository root manifest points Pi at the committed generated
 skills in `targets/pi/skills`.
 
-To test a branch before merge, pin that ref:
+To test a branch, tag, or commit before merge, configure that ref:
 
 ```bash
-pi install git:github.com/oliver-kriska/claude-elixir-phoenix@feat/pi-skills-package
+pi install git:github.com/oliver-kriska/claude-elixir-phoenix@<branch-tag-or-commit>
 ```
 
 ## Use skills
@@ -62,11 +62,11 @@ Update the installed Git package:
 pi update git:github.com/oliver-kriska/claude-elixir-phoenix
 ```
 
-Pi treats every explicit `@ref` as pinned to that configured ref name. Updating
-reconciles the checkout to that same ref; a moving branch name can therefore
-resolve to a newer commit, while a tag or commit SHA normally remains fixed.
-Pi does not model branch names as unpinned dependencies. Run
-`pi install ...@new-ref` to deliberately change the configured ref.
+Pi accepts an explicit `@ref` as a branch, tag, or commit. Updates keep targeting
+that configured ref: a moving branch—and a moved tag—can resolve to a newer
+commit, while a commit SHA remains fixed. Run `pi install ...@new-ref` to
+deliberately change the configured target.
+
 Remove the user-level package with:
 
 ```bash

--- a/docs/runtime-support.md
+++ b/docs/runtime-support.md
@@ -55,7 +55,7 @@ without Tidewave, named custom agents, or Claude-only task APIs.
 | Amp | Command palette → `skill: invoke`, or explicitly request the skill in the prompt | Direct GitHub Agent Skills install | [Amp guide](amp.md) |
 | Codex | `$elixir-phoenix:phx-investigate`, `$elixir-phoenix:phx-review` | Native Codex Git marketplace plugin | [Codex guide](codex.md) |
 | Pi | `/skill:phx-investigate`, `/skill:phx-review` | Native Pi Git package | [Pi guide](pi.md) |
-| OpenCode | Ask the skill tool to load the skill; 1.17.2 also accepts `/phx-investigate` and `/phx-review` | Sparse Git checkout | [OpenCode guide](opencode.md) |
+| OpenCode | Ask the skill tool to load the skill; in the tested 1.17.2 setup, `/phx-investigate` and `/phx-review` also work | Sparse Git checkout | [OpenCode guide](opencode.md) |
 
 Codex plugin skills are qualified by the plugin manifest name. OpenCode 1.17.2
 does not provide a native Git skills-package installer, so a sparse checkout is
@@ -68,8 +68,8 @@ update, clean reinstall, ref change, and uninstall affect newly started
 processes. Standalone list/debug commands are already fresh processes; they do
 not refresh the catalog of an existing interactive session.
 
-The current local acceptance baseline is Amp 0.0.1784796539-g051498, Codex CLI
-0.145.0, Pi 0.81.1, and OpenCode 1.17.2.
+The local acceptance run recorded on 2026-07-23 used Amp
+0.0.1784809706-g96cc8a, Codex CLI 0.145.0, Pi 0.81.1, and OpenCode 1.17.2.
 
 ## Runtime-specific boundaries
 
@@ -156,6 +156,11 @@ Do not pass `--ignore-user-config` when testing Codex plugin hooks: that option
 suppresses the installed plugin hooks as well as unrelated user configuration.
 An isolated `HOME` and `CODEX_HOME` provide the required separation without
 disabling the behavior under test.
+
+For Pi, isolate `HOME`, `PI_CODING_AGENT_DIR`, and
+`PI_CODING_AGENT_SESSION_DIR`; remove inherited `PI_PACKAGE_DIR`. Set
+`PI_OFFLINE=1`, `PI_SKIP_VERSION_CHECK=1`, and `PI_TELEMETRY=0` to keep package
+discovery model-free and offline.
 
 For OpenCode, isolate every XDG root in addition to `HOME`:
 

--- a/plugins/elixir-phoenix/skills/deps-audit/references/skill-checklist.md
+++ b/plugins/elixir-phoenix/skills/deps-audit/references/skill-checklist.md
@@ -91,4 +91,4 @@ make eval              # confirm pass
 ```
 
 If only one skill or agent changed, `make eval` runs in <30 s. The
-full `make eval-all` over 50 skills + 25 agents takes ~5 min.
+full `make eval-all` over 51 skills + 26 agents takes ~5 min.

--- a/scripts/generated_target_snapshots.json
+++ b/scripts/generated_target_snapshots.json
@@ -4,22 +4,22 @@
     "amp": {
       "entries": 379,
       "files": 251,
-      "sha256": "d01ed7ed77eaafdbf21c489b9e6e7254bdbabc3340192c3a8838ad11147d23da"
+      "sha256": "7048f5c063e92570975fd03712463532e5948d3c8850b7ac1f224c5dc6fff1aa"
     },
     "codex": {
       "entries": 385,
       "files": 254,
-      "sha256": "a8bc54fd7ff4aea5ed74172c5cde10caffe825ebeeb6b4c1b0a7d6966641294d"
+      "sha256": "5f0c84ff7d7e7a82204c85094109f38f0011c0401c91969c7206377dbad52a94"
     },
     "opencode": {
       "entries": 379,
       "files": 251,
-      "sha256": "35ae26f8e6217033545d663bf1dadb1b1fcf9c1d14308335a9a4fac8c4e1ee79"
+      "sha256": "70889e8592dac48e555010b22e2f70b69038dc5c4a7c5a7654cc063ea1dbd24b"
     },
     "pi": {
       "entries": 380,
       "files": 252,
-      "sha256": "8450bbe456a5be100d9f39be43914b29a535a184247517f1e3370e74bcce9c41"
+      "sha256": "06a05357a49315bcee420abb18f5bf5372a9aca332942af7649aed40386e6d54"
     }
   }
 }

--- a/targets/amp/skills/phx-deps-audit/references/skill-checklist.md
+++ b/targets/amp/skills/phx-deps-audit/references/skill-checklist.md
@@ -91,4 +91,4 @@ make eval              # confirm pass
 ```
 
 If only one skill or agent changed, `make eval` runs in <30 s. The
-full `make eval-all` over 50 skills + 25 agents takes ~5 min.
+full `make eval-all` over 51 skills + 26 agents takes ~5 min.

--- a/targets/codex/skills/phx-deps-audit/references/skill-checklist.md
+++ b/targets/codex/skills/phx-deps-audit/references/skill-checklist.md
@@ -91,4 +91,4 @@ make eval              # confirm pass
 ```
 
 If only one skill or agent changed, `make eval` runs in <30 s. The
-full `make eval-all` over 50 skills + 25 agents takes ~5 min.
+full `make eval-all` over 51 skills + 26 agents takes ~5 min.

--- a/targets/opencode/skills/phx-deps-audit/references/skill-checklist.md
+++ b/targets/opencode/skills/phx-deps-audit/references/skill-checklist.md
@@ -91,4 +91,4 @@ make eval              # confirm pass
 ```
 
 If only one skill or agent changed, `make eval` runs in <30 s. The
-full `make eval-all` over 50 skills + 25 agents takes ~5 min.
+full `make eval-all` over 51 skills + 26 agents takes ~5 min.

--- a/targets/pi/skills/phx-deps-audit/references/skill-checklist.md
+++ b/targets/pi/skills/phx-deps-audit/references/skill-checklist.md
@@ -91,4 +91,4 @@ make eval              # confirm pass
 ```
 
 If only one skill or agent changed, `make eval` runs in <30 s. The
-full `make eval-all` over 50 skills + 25 agents takes ~5 min.
+full `make eval-all` over 51 skills + 26 agents takes ~5 min.


### PR DESCRIPTION
## Summary

- audit README, changelog, security, contributor guidance, and all four generated-runtime guides against the merged implementation
- correct live inventory counts: 51 skills, 26 agents, 140 references, 30 hook registrations, and 207 tests
- distinguish raw SkillSpector results (66 SAFE, 7 CAUTION, 4 reviewed DNI findings) from the baseline-aware gate (77 scanned, 0 flagged)
- clarify Codex review refs, Pi ref-update behavior, OpenCode invocation/collision behavior, runtime isolation, and dated smoke-test versions
- regenerate the canonical dependency-audit reference into Amp, Codex, Pi, and OpenCode and update reviewed target snapshots

## Verification

- `make lint`
- `make test` — 207 passed
- `make security` — 77 components scanned, 0 flagged after reviewed baselines
- `make generated-skills-sync` — 51 skills in every target, snapshots clean
- `make amp-runtime-smoke` — Amp `0.0.1784809706-g96cc8a`, 51 skills
- `make codex-runtime-smoke` — Codex CLI `0.145.0`, 51 skills
- `make pi-runtime-smoke` — Pi `0.81.1`, 51 skills
- `make opencode-runtime-smoke` — OpenCode `1.17.2`, 51 skills
- fresh paid `make eval-full` — passed; 51 skills tested with Claude Haiku 4.5, 92% average trigger accuracy
- focused external correctness review of runtime lifecycle and security wording

The fresh behavioral run exposed four descriptions below the 75% per-skill target (`pr-review` 50%, `testing` 60%, `full` 67%, `help` 67%). They are pre-existing routing-quality follow-ups rather than documentation defects; this PR does not hide or tune against those results.
