### PR TITLE
fix(eval): make behavioral trigger gates reliable

### DIFF
--- a/.claude/skills/plugin-dev-workflow/SKILL.md
+++ b/.claude/skills/plugin-dev-workflow/SKILL.md
@@ -17,7 +17,7 @@ Run `make help` to see all available commands:
 make eval          # Quick: lint + score changed skills/agents
 make eval-all      # Full: all 51 skills + 26 agents
 make eval-fix      # Auto-fix + show failures
-make test          # 207 pytest tests for eval framework and port tooling
+make test          # 220 pytest tests for eval framework and port tooling
 make ci            # Full CI pipeline
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,9 +370,10 @@ npm install  # Pre-commit hooks + linting
 make help          # Show all commands
 make lint          # Lint markdown
 make lint-fix      # Auto-fix lint
-make test          # 207 pytest tests for eval framework and port tooling
-make eval          # Quick: lint + score changed skills/agents + trigger accuracy (cached)
-make eval-all      # Score all 51 skills + 26 agents + trigger accuracy
+make test          # 220 pytest tests for eval framework and port tooling
+make eval          # Quick: lint + structurally score changed skills/agents
+make eval-all      # Structurally score all 51 skills + 26 agents
+make eval-full     # Structural checks + fresh per-skill behavioral gate
 make eval-fix      # Auto-fix lint + show failures + suggest autoresearch
 make eval-tournament # Run tournament on weak skills (<75% trigger accuracy)
 make ci            # Full CI pipeline: lint + test + validate + eval + security
@@ -380,8 +381,9 @@ make ci            # Full CI pipeline: lint + test + validate + eval + security
 
 ### Eval Framework (lab/eval/)
 
-The plugin has a deterministic 8-dimension scoring system for skills and
-5-dimension scoring for agents. **Run `make eval` after every skill/agent edit.**
+The plugin has seven deterministic structural dimensions plus a neutral
+behavioral slot for skills, and five deterministic dimensions for agents.
+**Run `make eval` after every skill/agent edit.**
 
 **When editing skills/agents, ALWAYS verify your changes pass eval:**
 
@@ -390,7 +392,7 @@ The plugin has a deterministic 8-dimension scoring system for skills and
 3. If FAIL: run `make eval-fix` to see exact failures and get fix suggestions
 4. Fix the issues and re-run until PASS
 
-**What eval checks** (skills — 8 dimensions):
+**What eval checks** (skills — 7 structural dimensions + behavioral slot):
 
 - completeness (sections, Iron Laws, frontmatter)
 - accuracy (cross-references valid)
@@ -399,7 +401,8 @@ The plugin has a deterministic 8-dimension scoring system for skills and
 - safety (Iron Laws, prohibitions, no dangerous patterns)
 - clarity (action density, no duplication, step coverage)
 - specificity (code examples, concrete vs vague)
-- behavioral (trigger accuracy via cached haiku tests)
+- behavioral (neutral during structural scoring; `make eval-full` runs a fresh
+  Haiku gate and requires every skill to reach 75% trigger accuracy)
 
 **What eval checks** (agents — 5 dimensions):
 

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,13 @@ eval-all: ## Score all 51 skills + 26 agents (structural)
 eval-fix: ## Auto-fix lint + show failures + suggest autoresearch command
 	@bash lab/eval/run_eval.sh --fix
 
-eval-full: ## Everything: structural + behavioral triggers (~60 min)
+eval-full: ## Structural + fresh behavioral gate; every skill must reach 75% (~60 min)
 	@bash lab/eval/run_eval.sh --all && bash lab/eval/run_eval.sh --triggers
 
 eval-ci: ## CI gate: lint + all skills + all agents
 	@bash lab/eval/run_eval.sh --ci
 
-eval-triggers: ## Re-run behavioral trigger tests (~60 min, uses haiku)
+eval-triggers: ## Re-run behavioral gate; every skill must reach 75% (~60 min, Haiku)
 	@bash lab/eval/run_eval.sh --triggers
 
 eval-multimodel: ## Run trigger eval against sonnet (slow, ~$$3, ~3 hr). Override: MODEL=opus make eval-multimodel

--- a/README.md
+++ b/README.md
@@ -824,7 +824,7 @@ make help             # Show all available commands
 make eval             # Quick: lint + score changed skills/agents only
 make eval-all         # Full structural: all 51 skills + all 26 agents
 make eval-fix         # Auto-fix lint + show failures + suggest autoresearch
-make test             # 207 pytest tests for eval framework and port tooling
+make test             # 220 pytest tests for eval framework and port tooling
 make generated-skills-sync # Regenerate and verify all four runtime targets
 make ci               # Full CI: lint + test + validate + eval + security (same as GitHub Actions)
 ```
@@ -852,7 +852,10 @@ npm run eval:fix
 claude -p 'Run autoresearch...' --allowedTools 'Edit,Read,Write,Bash,Glob,Grep'
 ```
 
-The eval framework uses 24 deterministic Python matchers + haiku-based behavioral trigger testing. See `lab/eval/` for details.
+The eval framework uses 24 deterministic Python matchers plus a separate,
+fresh Haiku behavioral gate. `make eval-full` requires every skill to reach 75%
+trigger accuracy; ignored local result caches never affect structural CI. See
+`lab/eval/` for details.
 
 ### Analyze your sessions to improve the plugin
 

--- a/lab/eval/README.md
+++ b/lab/eval/README.md
@@ -9,11 +9,14 @@ we evaluated. It dynamically resolves evaluator classes by string ID, lazily
 importing modules on first use.
 
 **Current state**: 8 dimension modules dispatched via an explicit
-`DIMENSION_MODULES` dict at `lab/eval/scorer.py:18-27` (completeness, accuracy,
-conciseness, triggering, safety, clarity, specificity, behavioral). Matcher
-dispatch lives in `lab/eval/agent_matchers.py` and `lab/eval/matchers.py` and
-follows the same explicit-mapping shape — roughly 12 matchers covered by ~24
-deterministic matcher tests.
+`DIMENSION_MODULES` dict at `lab/eval/scorer.py:18-27`. Seven are deterministic
+structural checks (completeness, accuracy, conciseness, triggering, safety,
+clarity, specificity); behavioral is neutral unless cache use is explicitly
+enabled. Fresh paid trigger evaluation is a separate per-skill gate, so ignored
+local results never affect structural CI. Matcher dispatch lives in
+`lab/eval/agent_matchers.py` and `lab/eval/matchers.py` and follows the same
+explicit-mapping shape — roughly 12 matchers covered by ~24 deterministic
+matcher tests.
 
 **Rationale**: at our scale the indirection costs more than it saves. We have
 explicit imports, IDE jump-to-definition works on every dispatch site, and there

--- a/lab/eval/dimensions/behavioral.py
+++ b/lab/eval/dimensions/behavioral.py
@@ -1,8 +1,9 @@
 """Behavioral dimension: Does the skill trigger correctly for real user prompts?
 
-Uses cached trigger test results from lab/eval/triggers/results/.
-If no cached results exist, returns a neutral score (dimension skipped).
-Run trigger_scorer.py first to populate cache.
+Structural scoring is deterministic and therefore ignores the local, Git-ignored
+trigger cache by default. Set ``EVAL_USE_TRIGGER_CACHE=1`` for an explicit local
+diagnostic that incorporates cached results. Fresh paid runs are gated directly
+by ``trigger_scorer.py``.
 """
 
 import json
@@ -15,26 +16,39 @@ TRIGGERS_RESULTS_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     "triggers", "results"
 )
+CACHE_OPT_IN_ENV = "EVAL_USE_TRIGGER_CACHE"
+
+
+def _neutral(skill_name: str, evidence: str) -> DimensionResult:
+    return DimensionResult(
+        dimension="behavioral",
+        score=1.0,
+        passed=0, failed=0, total=0,
+        assertions=[AssertionResult(
+            id="behavioral-0",
+            check_type="trigger_accuracy",
+            description="Trigger cache explicitly enabled",
+            passed=True,
+            evidence=evidence,
+        )],
+    )
 
 
 def score(content: str, dimension: EvalDimension, skill_path: str = "", plugin_root: str = "") -> DimensionResult:
-    """Score behavioral dimension using cached trigger results."""
+    """Score cached trigger results only after an explicit opt-in."""
     skill_name = os.path.basename(os.path.dirname(skill_path)) if skill_path else ""
     cache_path = os.path.join(TRIGGERS_RESULTS_DIR, f"{skill_name}.json")
 
+    if os.environ.get(CACHE_OPT_IN_ENV) != "1":
+        return _neutral(
+            skill_name,
+            f"Local trigger cache disabled for deterministic scoring; set {CACHE_OPT_IN_ENV}=1 to include it",
+        )
+
     if not os.path.isfile(cache_path):
-        # No cached results — return neutral (don't penalize skills without trigger tests)
-        return DimensionResult(
-            dimension="behavioral",
-            score=1.0,
-            passed=0, failed=0, total=0,
-            assertions=[AssertionResult(
-                id="behavioral-0",
-                check_type="trigger_accuracy",
-                description="Trigger test results cached",
-                passed=True,
-                evidence=f"No trigger cache for {skill_name} — skipping (neutral)",
-            )],
+        return _neutral(
+            skill_name,
+            f"No trigger cache for {skill_name} — skipping (neutral)",
         )
 
     with open(cache_path) as f:

--- a/lab/eval/run_eval.sh
+++ b/lab/eval/run_eval.sh
@@ -7,7 +7,7 @@
 #   ./lab/eval/run_eval.sh --skills     # Score all skills only
 #   ./lab/eval/run_eval.sh --agents     # Score all agents only
 #   ./lab/eval/run_eval.sh --changed    # Only changed since last eval (default)
-#   ./lab/eval/run_eval.sh --triggers   # Re-run behavioral trigger tests (~$1.50, ~60min)
+#   ./lab/eval/run_eval.sh --triggers   # Re-run and gate behavioral triggers (~$1.50, ~60min)
 #
 # Exit codes:
 #   0 = all pass (>= 0.95)
@@ -150,105 +150,6 @@ run_agents() {
     return 0
 }
 
-run_triggers_cached() {
-    local filter="$1"  # "all" or "changed"
-    local results_dir="$SCRIPT_DIR/triggers/results"
-
-    if [ ! -d "$results_dir" ]; then
-        echo "  No cached trigger results (run 'make eval-triggers' first)"
-        return 0
-    fi
-
-    local skills_to_check=()
-
-    if [ "$filter" = "changed" ]; then
-        # Get changed skills (same logic as run_skills)
-        local changed_files=""
-        changed_files=$(git diff --name-only HEAD -- 'plugins/elixir-phoenix/skills/' 2>/dev/null || echo "")
-        local staged
-        staged=$(git diff --cached --name-only -- 'plugins/elixir-phoenix/skills/' 2>/dev/null || echo "")
-        if [ -n "$staged" ]; then
-            changed_files=$(printf "%s\n%s" "$changed_files" "$staged")
-        fi
-        # Untracked (brand-new skills are invisible to git diff)
-        local untracked
-        untracked=$(git ls-files --others --exclude-standard -- 'plugins/elixir-phoenix/skills/' 2>/dev/null || echo "")
-        if [ -n "$untracked" ]; then
-            changed_files=$(printf "%s\n%s" "$changed_files" "$untracked")
-        fi
-        if [ -f "$LAST_EVAL_FILE" ]; then
-            local last_commit
-            last_commit=$(cat "$LAST_EVAL_FILE")
-            local since_last
-            since_last=$(git diff --name-only "$last_commit" HEAD -- 'plugins/elixir-phoenix/skills/' 2>/dev/null || echo "")
-            if [ -n "$since_last" ]; then
-                changed_files=$(printf "%s\n%s" "$changed_files" "$since_last")
-            fi
-        fi
-        if [ -z "$changed_files" ]; then
-            echo "  No skill changes — skipping trigger check"
-            return 0
-        fi
-        while IFS= read -r file; do
-            local skill_name
-            skill_name=$(echo "$file" | sed -n 's|plugins/elixir-phoenix/skills/\([^/]*\)/.*|\1|p')
-            if [ -n "$skill_name" ]; then
-                skills_to_check+=("$skill_name")
-            fi
-        done <<< "$changed_files"
-        mapfile -t skills_to_check < <(printf '%s\n' "${skills_to_check[@]}" | sort -u)
-    else
-        # All skills with cached results
-        for f in "$results_dir"/*.json; do
-            local base
-            base=$(basename "$f" .json)
-            [ "$base" = "_aggregate" ] && continue
-            skills_to_check+=("$base")
-        done
-    fi
-
-    if [ ${#skills_to_check[@]} -eq 0 ]; then
-        return 0
-    fi
-
-    # Check cached trigger accuracy for each skill
-    python3 -c "
-import json, sys, os
-
-results_dir = '$results_dir'
-skills = '${skills_to_check[*]}'.split()
-threshold = 0.75
-below = []
-checked = 0
-no_cache = []
-
-for skill in skills:
-    cache_file = os.path.join(results_dir, f'{skill}.json')
-    if not os.path.isfile(cache_file):
-        no_cache.append(skill)
-        continue
-    with open(cache_file) as f:
-        data = json.load(f)
-    acc = data.get('accuracy', 1.0)
-    checked += 1
-    if acc < threshold:
-        below.append((skill, acc))
-
-if no_cache:
-    print(f'  {len(no_cache)} skills have no cached triggers: {\" \".join(no_cache[:5])}{\"...\" if len(no_cache)>5 else \"\"}')
-
-if below:
-    print(f'  {len(below)} skills BELOW {threshold:.0%} trigger accuracy:')
-    for skill, acc in sorted(below, key=lambda x: x[1]):
-        print(f'    {skill}: {acc:.0%}')
-    print(f'  Run: make eval-tournament')
-    sys.exit(1)
-elif checked > 0:
-    print(f'  {checked} skills checked — all >= {threshold:.0%} trigger accuracy (cached)')
-"
-    return $?
-}
-
 echo "=== Plugin Eval ==="
 echo ""
 
@@ -262,9 +163,6 @@ case "$MODE" in
         echo ""
         echo "--- Agents (all) ---"
         run_agents "all" || FAILURES=$((FAILURES + 1))
-        echo ""
-        echo "--- Trigger Accuracy (cached) ---"
-        run_triggers_cached "all" || FAILURES=$((FAILURES + 1))
         ;;
     --skills)
         echo "--- Skills (all) ---"
@@ -283,9 +181,6 @@ case "$MODE" in
         echo ""
         echo "--- Agents (changed) ---"
         run_agents "changed" || FAILURES=$((FAILURES + 1))
-        echo ""
-        echo "--- Trigger Accuracy (cached, changed skills) ---"
-        run_triggers_cached "changed" || FAILURES=$((FAILURES + 1))
         ;;
     --triggers)
         echo "--- Behavioral Triggers (all, ~\$1.50) ---"
@@ -293,7 +188,7 @@ case "$MODE" in
         python3 -m lab.eval.trigger_scorer --all --summary
         ;;
     --ci)
-        echo "--- CI Gate: Lint + All Skills + All Agents + Triggers ---"
+        echo "--- Structural CI Gate: Lint + All Skills + All Agents ---"
         echo ""
         echo "--- Lint ---"
         npm run lint 2>&1
@@ -308,9 +203,6 @@ case "$MODE" in
         echo ""
         echo "--- Agents ---"
         run_agents "all" || FAILURES=$((FAILURES + 1))
-        echo ""
-        echo "--- Trigger Accuracy (cached) ---"
-        run_triggers_cached "all" || FAILURES=$((FAILURES + 1))
         ;;
     --fix)
         echo "--- Auto-Fix: lint + find failures + suggest fixes ---"

--- a/lab/eval/tests/test_behavioral_gate.py
+++ b/lab/eval/tests/test_behavioral_gate.py
@@ -1,0 +1,236 @@
+"""Tests for deterministic structural scoring and paid behavioral gates."""
+
+import json
+import os
+import subprocess
+import sys
+
+from lab.eval.dimensions import behavioral
+from lab.eval.schemas import EvalDimension
+from lab.eval import trigger_scorer
+
+
+def test_structural_scoring_ignores_ambient_trigger_cache(tmp_path, monkeypatch):
+    cache = tmp_path / "demo.json"
+    cache.write_text(
+        json.dumps(
+            {
+                "accuracy": 0.0,
+                "precision": 0.0,
+                "recall": 0.0,
+                "correct": 0,
+                "total": 10,
+                "tp": 0,
+                "fp": 5,
+                "fn": 5,
+            }
+        )
+    )
+    monkeypatch.setattr(behavioral, "TRIGGERS_RESULTS_DIR", str(tmp_path))
+    monkeypatch.delenv(behavioral.CACHE_OPT_IN_ENV, raising=False)
+
+    dimension = EvalDimension(name="behavioral", weight=0.1, checks=[])
+    result = behavioral.score("", dimension, skill_path="/skills/demo/SKILL.md")
+
+    assert result.score == 1.0
+    assert "disabled for deterministic scoring" in result.assertions[0].evidence
+
+
+def test_trigger_cache_requires_explicit_opt_in(tmp_path, monkeypatch):
+    cache = tmp_path / "demo.json"
+    cache.write_text(
+        json.dumps(
+            {
+                "accuracy": 0.5,
+                "precision": 1.0,
+                "recall": 0.0,
+                "correct": 5,
+                "total": 10,
+                "tp": 0,
+                "fp": 0,
+                "fn": 5,
+            }
+        )
+    )
+    monkeypatch.setattr(behavioral, "TRIGGERS_RESULTS_DIR", str(tmp_path))
+    monkeypatch.setenv(behavioral.CACHE_OPT_IN_ENV, "1")
+
+    dimension = EvalDimension(name="behavioral", weight=0.1, checks=[])
+    result = behavioral.score("", dimension, skill_path="/skills/demo/SKILL.md")
+
+    assert result.score < 1.0
+    assert result.failed == 2
+
+
+def test_invalid_canonical_description_fails_preflight(tmp_path, monkeypatch):
+    skill_dir = tmp_path / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: demo\ndescription:\n---\n")
+    monkeypatch.setattr(trigger_scorer, "PLUGIN_ROOT", str(tmp_path))
+
+    try:
+        trigger_scorer.load_all_descriptions()
+    except ValueError as error:
+        assert "demo" in str(error)
+    else:
+        raise AssertionError("invalid canonical description passed preflight")
+
+
+def test_skills_below_threshold_are_ordered_worst_first():
+    results = {
+        "passing": {"accuracy": 0.75},
+        "middle": {"accuracy": 0.6},
+        "worst": {"accuracy": 0.4},
+    }
+
+    assert trigger_scorer.skills_below_threshold(results, 0.75) == [
+        ("worst", 0.4),
+        ("middle", 0.6),
+    ]
+
+
+def test_single_skill_cli_fails_below_threshold(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["trigger_scorer", "--skill", "demo", "--summary"])
+    monkeypatch.setattr(trigger_scorer, "load_all_descriptions", lambda: {"demo": "Demo"})
+    monkeypatch.setattr(
+        trigger_scorer,
+        "load_trigger_file",
+        lambda _name: {"should_trigger": ["demo"], "should_not_trigger": []},
+    )
+    monkeypatch.setattr(
+        trigger_scorer,
+        "score_skill_triggers",
+        lambda *_args, **_kwargs: {"accuracy": 0.74, "precision": 1.0, "recall": 0.5},
+    )
+
+    assert trigger_scorer.main() == 1
+
+
+def test_judge_retries_transient_cli_failure(monkeypatch):
+    attempts = iter(
+        [
+            subprocess.CompletedProcess([], 1, stdout="", stderr="temporary failure"),
+            subprocess.CompletedProcess([], 0, stdout="testing\n", stderr=""),
+        ]
+    )
+    monkeypatch.setattr(trigger_scorer.subprocess, "run", lambda *_args, **_kwargs: next(attempts))
+
+    assert trigger_scorer.ask_model({"testing": "Test Elixir code"}, "write a test") == ["testing"]
+
+
+def test_judge_failure_is_not_scored_as_no_skill(monkeypatch):
+    failure = subprocess.CompletedProcess([], 1, stdout="", stderr="authentication failed")
+    monkeypatch.setattr(trigger_scorer.subprocess, "run", lambda *_args, **_kwargs: failure)
+
+    try:
+        trigger_scorer.ask_model({"testing": "Test Elixir code"}, "write a test")
+    except trigger_scorer.JudgeInvocationError as error:
+        assert "authentication failed" in str(error)
+    else:
+        raise AssertionError("judge infrastructure failure was silently scored")
+
+
+def test_judge_receives_complete_descriptions(monkeypatch):
+    captured = {}
+
+    def run(command, **_kwargs):
+        captured["prompt"] = command[2]
+        return subprocess.CompletedProcess(command, 0, stdout="testing\n", stderr="")
+
+    description = "A" * 150 + " CRITICAL ROUTING BOUNDARY"
+    monkeypatch.setattr(trigger_scorer.subprocess, "run", run)
+
+    assert trigger_scorer.ask_model({"testing": description}, "write a test") == ["testing"]
+    assert "CRITICAL ROUTING BOUNDARY" in captured["prompt"]
+
+
+def test_judge_retries_invalid_protocol_output(monkeypatch):
+    attempts = iter(
+        [
+            subprocess.CompletedProcess([], 0, stdout="I recommend testing.\n", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="testing\n", stderr=""),
+        ]
+    )
+    monkeypatch.setattr(trigger_scorer.subprocess, "run", lambda *_args, **_kwargs: next(attempts))
+
+    assert trigger_scorer.ask_model({"testing": "Test Elixir code"}, "write a test") == ["testing"]
+
+
+def test_judge_retries_cli_start_failure(monkeypatch):
+    attempts = iter(
+        [
+            OSError("temporarily unavailable"),
+            subprocess.CompletedProcess([], 0, stdout="testing\n", stderr=""),
+        ]
+    )
+
+    def run(*_args, **_kwargs):
+        result = next(attempts)
+        if isinstance(result, OSError):
+            raise result
+        return result
+
+    monkeypatch.setattr(trigger_scorer.subprocess, "run", run)
+
+    assert trigger_scorer.ask_model({"testing": "Test Elixir code"}, "write a test") == ["testing"]
+
+
+def test_all_cli_rejects_incomplete_fixture_set_before_scoring(tmp_path, monkeypatch):
+    (tmp_path / "one.json").write_text(json.dumps({"should_trigger": ["one"], "should_not_trigger": ["not one"]}))
+    monkeypatch.setattr(sys, "argv", ["trigger_scorer", "--all", "--summary"])
+    monkeypatch.setattr(trigger_scorer, "TRIGGERS_DIR", str(tmp_path))
+    monkeypatch.setattr(trigger_scorer, "load_all_descriptions", lambda: {"one": "One", "two": "Two"})
+    monkeypatch.setattr(
+        trigger_scorer,
+        "score_skill_triggers",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("paid scoring started before preflight")),
+    )
+
+    assert trigger_scorer.main() == 1
+
+
+def test_summary_run_persists_completed_aggregate(tmp_path, monkeypatch):
+    triggers_dir = tmp_path / "triggers"
+    triggers_dir.mkdir()
+    (triggers_dir / "demo.json").write_text(
+        json.dumps({"should_trigger": ["demo"], "should_not_trigger": ["not demo"]})
+    )
+    aggregate_path = tmp_path / "aggregate.json"
+    monkeypatch.setattr(sys, "argv", ["trigger_scorer", "--all", "--summary"])
+    monkeypatch.setattr(trigger_scorer, "TRIGGERS_DIR", str(triggers_dir))
+    monkeypatch.setattr(trigger_scorer, "load_all_descriptions", lambda: {"demo": "Demo"})
+    monkeypatch.setattr(trigger_scorer, "aggregate_path_for_model", lambda _model: str(aggregate_path))
+    monkeypatch.setattr(
+        trigger_scorer,
+        "score_skill_triggers",
+        lambda *_args, **_kwargs: {"accuracy": 1.0, "precision": 1.0, "recall": 1.0},
+    )
+
+    assert trigger_scorer.main() == 0
+    assert json.loads(aggregate_path.read_text())["skills_tested"] == 1
+
+
+def test_failed_skill_run_preserves_previous_cache(tmp_path, monkeypatch):
+    previous = {"accuracy": 1.0, "marker": "previous"}
+    cache_path = tmp_path / "testing.json"
+    cache_path.write_text(json.dumps(previous))
+    monkeypatch.setattr(trigger_scorer, "RESULTS_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        trigger_scorer,
+        "ask_model",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(trigger_scorer.JudgeInvocationError("failed")),
+    )
+
+    try:
+        trigger_scorer.score_skill_triggers(
+            "testing",
+            {"should_trigger": ["write a test"], "should_not_trigger": ["fix app code"]},
+            {"testing": "Test Elixir code"},
+        )
+    except trigger_scorer.JudgeInvocationError:
+        pass
+    else:
+        raise AssertionError("judge failure did not abort scoring")
+
+    assert json.loads(cache_path.read_text()) == previous
+    assert sorted(os.listdir(tmp_path)) == ["testing.json"]

--- a/lab/eval/trigger_scorer.py
+++ b/lab/eval/trigger_scorer.py
@@ -15,7 +15,7 @@ Usage:
     python3 -m lab.eval.trigger_scorer --all --model sonnet        # Evaluate against sonnet
     python3 -m lab.eval.trigger_scorer --skill plan --model claude-sonnet-4-6
 
-Cost: ~$0.001 per test prompt on haiku, ~$0.04 for all 45 skills × ~8 prompts.
+Cost: approximately $1.50 and 60 minutes for all 51 skills on Haiku.
 Sonnet is roughly 12× more expensive per call.
 """
 
@@ -25,6 +25,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timezone
 
 EVAL_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -39,6 +40,13 @@ PLUGIN_ROOT = os.path.join(PROJECT_ROOT, "plugins", "elixir-phoenix")
 TRIGGERS_DIR = os.path.join(EVAL_DIR, "triggers")
 RESULTS_DIR = os.path.join(TRIGGERS_DIR, "results")
 DEFAULT_MODEL = "claude-haiku-4-5"
+DEFAULT_MIN_ACCURACY = 0.75
+JUDGE_TIMEOUT_SECONDS = 60
+JUDGE_ATTEMPTS = 2
+
+
+class JudgeInvocationError(RuntimeError):
+    """The routing judge failed before producing a valid routing decision."""
 
 # CC CLI accepts both aliases and full IDs. Canonicalize so 'haiku' and
 # 'claude-haiku-4-5' share one cache rather than two.
@@ -90,9 +98,10 @@ def load_all_descriptions() -> dict[str, str]:
         with open(skill_path) as f:
             content = f.read()
         fm = parse_frontmatter(content)
-        desc = str(fm.get("description", ""))
-        if desc:
-            descriptions[name] = desc
+        description = fm.get("description")
+        if not isinstance(description, str) or not description.strip():
+            raise ValueError(f"canonical skill has no valid description: {name}")
+        descriptions[name] = description
     return descriptions
 
 
@@ -105,9 +114,58 @@ def load_trigger_file(skill_name: str) -> dict | None:
         return json.load(f)
 
 
+def load_all_trigger_files(skill_names: set[str]) -> dict[str, dict]:
+    """Load and validate the exact trigger-fixture set for canonical skills."""
+    fixture_names = {
+        os.path.splitext(name)[0]
+        for name in os.listdir(TRIGGERS_DIR)
+        if name.endswith(".json") and not name.startswith("_")
+    }
+    missing = sorted(skill_names - fixture_names)
+    stale = sorted(fixture_names - skill_names)
+    if missing or stale:
+        details = []
+        if missing:
+            details.append(f"missing fixtures: {', '.join(missing)}")
+        if stale:
+            details.append(f"fixtures without canonical skills: {', '.join(stale)}")
+        raise ValueError("trigger fixture set does not match canonical skills (" + "; ".join(details) + ")")
+
+    fixtures = {}
+    for name in sorted(skill_names):
+        fixture = load_trigger_file(name)
+        if not isinstance(fixture, dict):
+            raise ValueError(f"trigger fixture must be a JSON object: {name}")
+        for key in ("should_trigger", "should_not_trigger"):
+            prompts = fixture.get(key)
+            if not isinstance(prompts, list) or not all(isinstance(prompt, str) and prompt for prompt in prompts):
+                raise ValueError(f"trigger fixture {name} has invalid {key}")
+        if not fixture["should_trigger"] or not fixture["should_not_trigger"]:
+            raise ValueError(f"trigger fixture {name} must include positive and negative prompts")
+        fixtures[name] = fixture
+    return fixtures
+
+
+def _parse_judge_output(text: str, skill_names: set[str]) -> list[str] | None:
+    """Parse the judge's deliberately small output protocol."""
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if lines == ["none"]:
+        return []
+    if not 1 <= len(lines) <= 3:
+        return None
+
+    skills = []
+    for line in lines:
+        candidate = line.lstrip("-*0123456789.) ").strip().strip("`").strip()
+        if candidate not in skill_names or candidate in skills:
+            return None
+        skills.append(candidate)
+    return skills
+
+
 def ask_model(all_descriptions: dict[str, str], prompt: str, model: str = DEFAULT_MODEL) -> list[str]:
     """Ask the chosen routing-judge model which skill(s) it would load for a given prompt."""
-    desc_list = "\n".join(f"- {name}: {desc[:150]}" for name, desc in all_descriptions.items())
+    desc_list = "\n".join(f"- {name}: {desc}" for name, desc in all_descriptions.items())
 
     system_prompt = f"""You are testing skill routing for a Claude Code plugin.
 
@@ -120,40 +178,45 @@ Which skill(s) should be loaded? Reply with ONLY the skill name(s), one per line
 If no skill should be loaded, reply with "none".
 List at most 3 skills, ordered by relevance."""
 
-    try:
-        result = subprocess.run(
-            [
-                "claude", "-p", system_prompt,
-                "--model", model,
-                "--output-format", "text",
-                "--max-budget-usd", "0.50",
-                "--no-session-persistence",
-            ],
-            capture_output=True, text=True, timeout=30,
-        )
-
-        if result.returncode != 0:
-            return []
+    errors = []
+    for attempt in range(1, JUDGE_ATTEMPTS + 1):
+        try:
+            result = subprocess.run(
+                [
+                    "claude", "-p", system_prompt,
+                    "--model", model,
+                    "--output-format", "text",
+                    "--max-budget-usd", "0.50",
+                    "--no-session-persistence",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=JUDGE_TIMEOUT_SECONDS,
+                stdin=subprocess.DEVNULL,
+            )
+        except subprocess.TimeoutExpired:
+            errors.append(f"attempt {attempt}: timed out after {JUDGE_TIMEOUT_SECONDS}s")
+            continue
+        except OSError as error:
+            errors.append(f"attempt {attempt}: could not start Claude CLI: {error}")
+            continue
 
         text = result.stdout.strip()
-        # Parse skill names from response — one per line, strip bullets/numbers
-        skills = []
-        for line in text.split("\n"):
-            line = line.strip().lstrip("-*0123456789.) ").strip()
-            # Remove explanations after dashes or parentheses
-            if " — " in line:
-                line = line.split(" — ")[0].strip()
-            if " (" in line:
-                line = line.split(" (")[0].strip()
-            if " -" in line:
-                line = line.split(" -")[0].strip()
-            line = line.strip("`").strip()
-            if line and line != "none" and not line.startswith("No "):
-                skills.append(line)
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or "no output"
+            errors.append(f"attempt {attempt}: exit {result.returncode}: {detail}")
+            continue
+        if not text:
+            errors.append(f"attempt {attempt}: Claude CLI returned empty output")
+            continue
+
+        skills = _parse_judge_output(text, set(all_descriptions))
+        if skills is None:
+            errors.append(f"attempt {attempt}: invalid routing response: {text}")
+            continue
         return skills
 
-    except (subprocess.TimeoutExpired, Exception):
-        return []
+    raise JudgeInvocationError("routing judge failed: " + "; ".join(errors))
 
 
 def score_triggers(request: ScoreRequest) -> ScoreResult:
@@ -276,16 +339,41 @@ def score_skill_triggers(
     score_data = result.to_dict()
 
     if not result.cache_hit:
-        os.makedirs(cache_dir, exist_ok=True)
         cache_path = os.path.join(cache_dir, f"{skill_name}.json")
-        with open(cache_path, "w") as f:
-            json.dump(score_data, f, indent=2)
-            f.write("\n")
+        _write_json_atomic(cache_path, score_data)
 
     return score_data
 
 
-def main():
+def _write_json_atomic(path: str, payload: dict) -> None:
+    """Replace a JSON result only after its complete contents reach disk."""
+    directory = os.path.dirname(path)
+    os.makedirs(directory, exist_ok=True)
+    temporary_path = None
+    try:
+        with tempfile.NamedTemporaryFile("w", dir=directory, delete=False) as temporary:
+            temporary_path = temporary.name
+            json.dump(payload, temporary, indent=2)
+            temporary.write("\n")
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path and os.path.exists(temporary_path):
+            os.unlink(temporary_path)
+
+
+def skills_below_threshold(results: dict[str, dict], threshold: float) -> list[tuple[str, float]]:
+    """Return skills below the required accuracy, ordered worst first."""
+    return sorted(
+        (
+            (name, float(result.get("accuracy", 0.0)))
+            for name, result in results.items()
+            if float(result.get("accuracy", 0.0)) < threshold
+        ),
+        key=lambda item: (item[1], item[0]),
+    )
+
+
+def main() -> int:
     parser = argparse.ArgumentParser(description="Test skill trigger accuracy against a routing-judge model")
     parser.add_argument("--skill", help="Test one skill")
     parser.add_argument("--all", action="store_true", help="Test all skills with trigger files")
@@ -296,9 +384,22 @@ def main():
         default=DEFAULT_MODEL,
         help=f"Routing-judge model (alias like 'sonnet' or full ID). Default: {DEFAULT_MODEL}",
     )
+    parser.add_argument(
+        "--min-accuracy",
+        type=float,
+        default=DEFAULT_MIN_ACCURACY,
+        help=f"Fail when any tested skill is below this accuracy. Default: {DEFAULT_MIN_ACCURACY}",
+    )
     args = parser.parse_args()
 
-    all_descriptions = load_all_descriptions()
+    if not 0.0 <= args.min_accuracy <= 1.0:
+        parser.error("--min-accuracy must be between 0 and 1")
+
+    try:
+        all_descriptions = load_all_descriptions()
+    except (OSError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
     judge_model = canonicalize_model(args.model)
 
     if args.skill:
@@ -311,17 +412,27 @@ def main():
             print(f"{args.skill} [{judge_model}]: accuracy={result['accuracy']:.0%} precision={result['precision']:.0%} recall={result['recall']:.0%}")
         else:
             print(json.dumps(result, indent=2))
+        if result["accuracy"] < args.min_accuracy:
+            print(
+                f"{args.skill} is below the {args.min_accuracy:.0%} minimum trigger accuracy",
+                file=sys.stderr,
+            )
+            return 1
 
     elif args.all:
+        try:
+            all_triggers = load_all_trigger_files(set(all_descriptions))
+        except (json.JSONDecodeError, OSError, ValueError) as error:
+            print(f"ERROR: {error}", file=sys.stderr)
+            return 1
+
         skills_tested = 0
         total_accuracy = 0
         results = {}
 
         print(f"Judge model: {judge_model}\n")
         for name in sorted(all_descriptions.keys()):
-            triggers = load_trigger_file(name)
-            if not triggers:
-                continue
+            triggers = all_triggers[name]
             print(f"  Testing {name}...", end=" ", flush=True)
             result = score_skill_triggers(name, triggers, all_descriptions, args.cache, model=judge_model)
             results[name] = result
@@ -332,23 +443,29 @@ def main():
         avg = total_accuracy / skills_tested if skills_tested else 0
         print(f"\n{skills_tested} skills tested against {judge_model}, average accuracy: {avg:.0%}")
 
-        if not args.summary:
-            # Save aggregate
-            aggregate_path = aggregate_path_for_model(judge_model)
-            os.makedirs(os.path.dirname(aggregate_path), exist_ok=True)
-            with open(aggregate_path, "w") as f:
-                json.dump({
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
-                    "model": judge_model,
-                    "skills_tested": skills_tested,
-                    "average_accuracy": round(avg, 4),
-                    "per_skill": {k: {"accuracy": v["accuracy"], "precision": v["precision"], "recall": v["recall"]}
-                                  for k, v in results.items()},
-                }, f, indent=2)
+        below = skills_below_threshold(results, args.min_accuracy)
+        if below:
+            print(f"\n{len(below)} skills below the {args.min_accuracy:.0%} minimum:")
+            for name, accuracy in below:
+                print(f"  {name}: {accuracy:.0%}")
+
+        _write_json_atomic(aggregate_path_for_model(judge_model), {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "model": judge_model,
+            "skills_tested": skills_tested,
+            "average_accuracy": round(avg, 4),
+            "per_skill": {k: {"accuracy": v["accuracy"], "precision": v["precision"], "recall": v["recall"]}
+                          for k, v in results.items()},
+        })
+
+        if below:
+            return 1
 
     else:
         parser.print_help()
 
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/plugins/elixir-phoenix/skills/examples/SKILL.md
+++ b/plugins/elixir-phoenix/skills/examples/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phx:examples
-description: Provide examples and walkthroughs for Phoenix, LiveView, Ecto, OTP patterns. Use when "how do I...", "show me an example", or "what does X look like".
+description: "Provide Phoenix, LiveView, Ecto, OTP, or Oban examples and walkthroughs. Use for sample code, step-by-step guidance, or what an implementation/output looks like. NOT for debugging, direct implementation, best practices, or audits."
 effort: low
 ---
 

--- a/plugins/elixir-phoenix/skills/full/SKILL.md
+++ b/plugins/elixir-phoenix/skills/full/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phx:full
-description: Use for large features spanning multiple contexts or autonomous end-to-end implementation. Runs the full plan-implement-review-compound cycle with specialist agents. NOT for executing an existing plan file — use /phx:work for that.
+description: "Deliver a large, cross-domain Phoenix feature or complete end-to-end system through planning, implementation, verification, and review. Use when several coordinated workflows or contexts must ship together. NOT for an existing plan; use /phx:work."
 effort: high
 argument-hint: <feature description> [--codex]
 ---

--- a/plugins/elixir-phoenix/skills/help/SKILL.md
+++ b/plugins/elixir-phoenix/skills/help/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phx:help
-description: "Recommend the right /phx: command for planning, review, debug, deploy, or test tasks. Use when \"which command\", \"what should I use\", or \"how do I\". NOT for /help."
+description: "Choose Phoenix review, plan, debug, or test command. Use when user asks which /phx: command or plugin skill handles a task; do not route only to a domain skill. NEVER for bare /help; NOT for ambiguous requests (use intent-detection) or a plugin tour."
 argument-hint: "[description of what you want to do]"
 effort: low
 ---

--- a/plugins/elixir-phoenix/skills/intent-detection/SKILL.md
+++ b/plugins/elixir-phoenix/skills/intent-detection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: intent-detection
-description: "Route ambiguous Phoenix/LiveView/Ecto work requests to the correct /phx: workflow. Use when intent is unclear, mixed (bug fix vs. refactor), or scope is ambiguous."
+description: "Route ambiguous or mixed Phoenix/LiveView/Ecto requests before choosing a workflow. Use when user is unsure where to start/how to approach work, asks for the right workflow, or combines intents such as fixing and refactoring. NOT for a clear task."
 effort: medium
 user-invocable: false
 ---

--- a/plugins/elixir-phoenix/skills/pr-review/SKILL.md
+++ b/plugins/elixir-phoenix/skills/pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phx:pr-review
-description: Address PR review threads on Elixir/Phoenix code — fetch unresolved threads, fix code, reply, and resolve each thread. Use when the user shares a PR URL or mentions reviewer feedback.
+description: "Address feedback left on a GitHub pull request: fetch unresolved review threads, make agreed Elixir/Phoenix code fixes, reply, and resolve. Use for a PR URL/number or reviewer comments. NOT for pre-PR review, findings triage, or CI monitoring."
 effort: high
 argument-hint: <PR number or URL> [--fix] [--bots-only] [--no-resolve]
 ---

--- a/plugins/elixir-phoenix/skills/testing/SKILL.md
+++ b/plugins/elixir-phoenix/skills/testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing
-description: "Elixir testing patterns — ExUnit, Mox, factories, LiveView test helpers. Use when working on *_test.exs, test/support/, factory files, or fixing test failures."
+description: "Write or repair Elixir tests with ExUnit, sandbox isolation, async reliability, Mox, ExMachina, and LiveViewTest. Use for test files, test setup, or failing/flaky tests. NOT for investigating an application bug outside the test suite."
 effort: medium
 user-invocable: false
 paths:

--- a/scripts/generated_target_snapshots.json
+++ b/scripts/generated_target_snapshots.json
@@ -4,22 +4,22 @@
     "amp": {
       "entries": 379,
       "files": 251,
-      "sha256": "7048f5c063e92570975fd03712463532e5948d3c8850b7ac1f224c5dc6fff1aa"
+      "sha256": "f4f7e803458c27c1fc44cb729757f143bf6e21aa416314b4767a26363f25abc0"
     },
     "codex": {
       "entries": 385,
       "files": 254,
-      "sha256": "5f0c84ff7d7e7a82204c85094109f38f0011c0401c91969c7206377dbad52a94"
+      "sha256": "59a6aa21c856a3d848d2ca8ab56eb07985c2803de2cc839b82d016b9fe2058c3"
     },
     "opencode": {
       "entries": 379,
       "files": 251,
-      "sha256": "70889e8592dac48e555010b22e2f70b69038dc5c4a7c5a7654cc063ea1dbd24b"
+      "sha256": "91418dafa93ca34e001eca1c93cf55bba21fbdd8b1df9b51c56a5c37d300cab8"
     },
     "pi": {
       "entries": 380,
       "files": 252,
-      "sha256": "06a05357a49315bcee420abb18f5bf5372a9aca332942af7649aed40386e6d54"
+      "sha256": "2b4372f193aa6737246b9d0fbc4ed1baeac49922cbe7398014dd291f77de3eec"
     }
   }
 }

--- a/scripts/port_lib/codex.py
+++ b/scripts/port_lib/codex.py
@@ -603,8 +603,8 @@ the initial attempt plus N retries. Review is read-only; findings return WORKING
 """
 
 WHOLESALE_SOURCE_SHA256 = {
-    "pr-review/SKILL.md": "64baf279488cf379d65e276d073dd4c6c4e75d3060b6daac2e1a071b979131a4",
-    "full/SKILL.md": "69af4a8f08319f7ca86432765b0662944b068db2ad8a5bc945cf39f308963545",
+    "pr-review/SKILL.md": "80e91bd0737cf677ca59fe10aa3573afcc739f87685f20f258aa7bc8c650bdf8",
+    "full/SKILL.md": "d72cc731ff8fe0ba6ec4c0123cb86cdb1ca9c86283c77057bd168ebfd9bb7cf6",
     "full/references/execution-steps.md": "b608c047414f9ad464f5c0ecc0eb1562f509cfdc30ef3782ed6b4e566a37382c",
     "full/references/safety-recovery.md": "94595d350b9e3c809e0762676b7d8c3b831782a51173db9213585bebc8869234",
     "full/references/example-run.md": "8b72b77afcf947127978c74c2de560fb7abc826e541f71fcd06835101dad7bc8",

--- a/targets/amp/skills/intent-detection/SKILL.md
+++ b/targets/amp/skills/intent-detection/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: intent-detection
-description: Route ambiguous Phoenix/LiveView/Ecto work requests to the correct phx-*
-  workflow. Use when intent is unclear, mixed (bug fix vs. refactor), or scope is
-  ambiguous.
+description: Route ambiguous or mixed Phoenix/LiveView/Ecto requests before choosing
+  a workflow. Use when user is unsure where to start/how to approach work, asks for
+  the right workflow, or combines intents such as fixing and refactoring. NOT for
+  a clear task.
 ---
 
 # Intent Detection — Workflow Routing

--- a/targets/amp/skills/phx-examples/SKILL.md
+++ b/targets/amp/skills/phx-examples/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: phx-examples
-description: Provide examples and walkthroughs for Phoenix, LiveView, Ecto, OTP patterns.
-  Use when "how do I...", "show me an example", or "what does X look like".
+description: Provide Phoenix, LiveView, Ecto, OTP, or Oban examples and walkthroughs.
+  Use for sample code, step-by-step guidance, or what an implementation/output looks
+  like. NOT for debugging, direct implementation, best practices, or audits.
 ---
 
 # Examples & Walkthroughs

--- a/targets/amp/skills/phx-full/SKILL.md
+++ b/targets/amp/skills/phx-full/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: phx-full
-description: Use for large features spanning multiple contexts or autonomous end-to-end
-  implementation. Runs the full plan-implement-review-compound cycle with specialist
-  agents. NOT for executing an existing plan file — use phx-work for that.
+description: Deliver a large, cross-domain Phoenix feature or complete end-to-end
+  system through planning, implementation, verification, and review. Use when several
+  coordinated workflows or contexts must ship together. NOT for an existing plan;
+  use phx-work.
 ---
 
 # Full Phoenix Feature Development

--- a/targets/amp/skills/phx-help/SKILL.md
+++ b/targets/amp/skills/phx-help/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: phx-help
-description: Recommend the right phx-* command for planning, review, debug, deploy,
-  or test tasks. Use when "which command", "what should I use", or "how do I". NOT
-  for /help.
+description: Choose Phoenix review, plan, debug, or test command. Use when user asks
+  which phx-* command or plugin skill handles a task; do not route only to a domain
+  skill. NEVER for bare /help; NOT for ambiguous requests (use intent-detection) or
+  a plugin tour.
 ---
 
 # Plugin Help — Interactive Command Advisor

--- a/targets/amp/skills/phx-pr-review/SKILL.md
+++ b/targets/amp/skills/phx-pr-review/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: phx-pr-review
-description: Address PR review threads on Elixir/Phoenix code — fetch unresolved threads,
-  fix code, reply, and resolve each thread. Use when the user shares a PR URL or mentions
-  reviewer feedback.
+description: 'Address feedback left on a GitHub pull request: fetch unresolved review
+  threads, make agreed Elixir/Phoenix code fixes, reply, and resolve. Use for a PR
+  URL/number or reviewer comments. NOT for pre-PR review, findings triage, or CI monitoring.'
 ---
 
 # PR Review Response

--- a/targets/amp/skills/testing/SKILL.md
+++ b/targets/amp/skills/testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: testing
-description: Elixir testing patterns — ExUnit, Mox, factories, LiveView test helpers.
-  Use when working on *_test.exs, test/support/, factory files, or fixing test failures.
+description: Write or repair Elixir tests with ExUnit, sandbox isolation, async reliability,
+  Mox, ExMachina, and LiveViewTest. Use for test files, test setup, or failing/flaky
+  tests. NOT for investigating an application bug outside the test suite.
 ---
 
 # Elixir Testing Reference

--- a/targets/codex/skills/intent-detection/SKILL.md
+++ b/targets/codex/skills/intent-detection/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: intent-detection
-description: Route ambiguous Phoenix/LiveView/Ecto work requests to the correct; Use
-  when intent is unclear, mixed (bug fix vs.…
+description: Route ambiguous or mixed Phoenix/LiveView/Ecto requests; Use when user
+  is unsure where to start/how to approach work…
 ---
 
 # Intent Detection — Workflow Routing

--- a/targets/codex/skills/phx-examples/SKILL.md
+++ b/targets/codex/skills/phx-examples/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: phx-examples
-description: Provide examples and walkthroughs for Phoenix, LiveView, Ecto, OTP; Use
-  when "how do I...", "show me an example"…
+description: Provide Phoenix, LiveView, Ecto, OTP, or Oban examples and walkthroughs.
+  Use for sample code, step-by-step guidance…
 ---
 
 # Examples & Walkthroughs

--- a/targets/codex/skills/phx-pr-review/SKILL.md
+++ b/targets/codex/skills/phx-pr-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: phx-pr-review
-description: Address PR review threads on Elixir/Phoenix code — fetch unresolved;
-  Use when the user shares a PR URL or mentions…
+description: 'Address feedback left on a GitHub pull request: fetch unresolved; Use
+  for a PR URL/number or reviewer comments.…'
 ---
 # PR Review Response
 

--- a/targets/codex/skills/testing/SKILL.md
+++ b/targets/codex/skills/testing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: testing
-description: Elixir testing patterns — ExUnit, Mox, factories, LiveView test helpers.
-  Use when working on *_test.exs…
+description: Write or repair Elixir tests with ExUnit, sandbox isolation, async; Use
+  for test files, test setup, or failing/flaky…
 ---
 
 # Elixir Testing Reference

--- a/targets/opencode/skills/intent-detection/SKILL.md
+++ b/targets/opencode/skills/intent-detection/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: intent-detection
-description: Route ambiguous Phoenix/LiveView/Ecto work requests to the correct /phx-*
-  workflow. Use when intent is unclear, mixed (bug fix vs. refactor), or scope is
-  ambiguous.
+description: Route ambiguous or mixed Phoenix/LiveView/Ecto requests before choosing
+  a workflow. Use when user is unsure where to start/how to approach work, asks for
+  the right workflow, or combines intents such as fixing and refactoring. NOT for
+  a clear task.
 ---
 
 # Intent Detection — Workflow Routing

--- a/targets/opencode/skills/phx-examples/SKILL.md
+++ b/targets/opencode/skills/phx-examples/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: phx-examples
-description: Provide examples and walkthroughs for Phoenix, LiveView, Ecto, OTP patterns.
-  Use when "how do I...", "show me an example", or "what does X look like".
+description: Provide Phoenix, LiveView, Ecto, OTP, or Oban examples and walkthroughs.
+  Use for sample code, step-by-step guidance, or what an implementation/output looks
+  like. NOT for debugging, direct implementation, best practices, or audits.
 ---
 
 # Examples & Walkthroughs

--- a/targets/opencode/skills/phx-help/SKILL.md
+++ b/targets/opencode/skills/phx-help/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: phx-help
-description: Recommend the right /phx-* command for planning, review, debug, deploy,
-  or test tasks. Use when "which command", "what should I use", or "how do I". NOT
-  for /help.
+description: Choose Phoenix review, plan, debug, or test command. Use when user asks
+  which /phx-* command or plugin skill handles a task; do not route only to a domain
+  skill. NEVER for bare /help; NOT for ambiguous requests (use intent-detection) or
+  a plugin tour.
 ---
 
 # Plugin Help — Interactive Command Advisor

--- a/targets/opencode/skills/phx-pr-review/SKILL.md
+++ b/targets/opencode/skills/phx-pr-review/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: phx-pr-review
-description: Address PR review threads on Elixir/Phoenix code — fetch unresolved threads,
-  fix code, reply, and resolve each thread. Use when the user shares a PR URL or mentions
-  reviewer feedback.
+description: 'Address feedback left on a GitHub pull request: fetch unresolved review
+  threads, make agreed Elixir/Phoenix code fixes, reply, and resolve. Use for a PR
+  URL/number or reviewer comments. NOT for pre-PR review, findings triage, or CI monitoring.'
 ---
 # PR Review Response
 

--- a/targets/opencode/skills/testing/SKILL.md
+++ b/targets/opencode/skills/testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: testing
-description: Elixir testing patterns — ExUnit, Mox, factories, LiveView test helpers.
-  Use when working on *_test.exs, test/support/, factory files, or fixing test failures.
+description: Write or repair Elixir tests with ExUnit, sandbox isolation, async reliability,
+  Mox, ExMachina, and LiveViewTest. Use for test files, test setup, or failing/flaky
+  tests. NOT for investigating an application bug outside the test suite.
 ---
 
 # Elixir Testing Reference

--- a/targets/pi/skills/intent-detection/SKILL.md
+++ b/targets/pi/skills/intent-detection/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: intent-detection
-description: Route ambiguous Phoenix/LiveView/Ecto work requests to the correct /skill:phx-*
-  workflow. Use when intent is unclear, mixed (bug fix vs. refactor), or scope is
-  ambiguous.
+description: Route ambiguous or mixed Phoenix/LiveView/Ecto requests before choosing
+  a workflow. Use when user is unsure where to start/how to approach work, asks for
+  the right workflow, or combines intents such as fixing and refactoring. NOT for
+  a clear task.
 ---
 
 # Intent Detection — Workflow Routing

--- a/targets/pi/skills/phx-examples/SKILL.md
+++ b/targets/pi/skills/phx-examples/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: phx-examples
-description: Provide examples and walkthroughs for Phoenix, LiveView, Ecto, OTP patterns.
-  Use when "how do I...", "show me an example", or "what does X look like".
+description: Provide Phoenix, LiveView, Ecto, OTP, or Oban examples and walkthroughs.
+  Use for sample code, step-by-step guidance, or what an implementation/output looks
+  like. NOT for debugging, direct implementation, best practices, or audits.
 ---
 
 # Examples & Walkthroughs

--- a/targets/pi/skills/phx-help/SKILL.md
+++ b/targets/pi/skills/phx-help/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: phx-help
-description: Recommend the right /skill:phx-* command for planning, review, debug,
-  deploy, or test tasks. Use when "which command", "what should I use", or "how do
-  I". NOT for /help.
+description: Choose Phoenix review, plan, debug, or test command. Use when user asks
+  which /skill:phx-* command or plugin skill handles a task; do not route only to
+  a domain skill. NEVER for bare /help; NOT for ambiguous requests (use intent-detection)
+  or a plugin tour.
 ---
 
 # Plugin Help — Interactive Command Advisor

--- a/targets/pi/skills/phx-pr-review/SKILL.md
+++ b/targets/pi/skills/phx-pr-review/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: phx-pr-review
-description: Address PR review threads on Elixir/Phoenix code — fetch unresolved threads,
-  fix code, reply, and resolve each thread. Use when the user shares a PR URL or mentions
-  reviewer feedback.
+description: 'Address feedback left on a GitHub pull request: fetch unresolved review
+  threads, make agreed Elixir/Phoenix code fixes, reply, and resolve. Use for a PR
+  URL/number or reviewer comments. NOT for pre-PR review, findings triage, or CI monitoring.'
 ---
 # PR Review Response
 

--- a/targets/pi/skills/testing/SKILL.md
+++ b/targets/pi/skills/testing/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: testing
-description: Elixir testing patterns — ExUnit, Mox, factories, LiveView test helpers.
-  Use when working on *_test.exs, test/support/, factory files, or fixing test failures.
+description: Write or repair Elixir tests with ExUnit, sandbox isolation, async reliability,
+  Mox, ExMachina, and LiveViewTest. Use for test files, test setup, or failing/flaky
+  tests. NOT for investigating an application bug outside the test suite.
 ---
 
 # Elixir Testing Reference


### PR DESCRIPTION
## Summary

- separate deterministic structural scoring from fresh paid behavioral evaluation so ignored local caches cannot change CI results
- require every canonical skill and trigger fixture before paid calls, send complete descriptions, retry transient judge failures, reject malformed judge output, and write result files atomically
- gate every skill at 75% rather than relying on aggregate accuracy
- sharpen generalized routing boundaries for `pr-review`, `testing`, `full`, `help`, `examples`, and `intent-detection`
- regenerate and snapshot Amp, Codex, Pi, and OpenCode targets

## Why

Structural eval previously incorporated ignored trigger caches when present. That made local results differ from hosted CI, while stale or partial caches could also make the gate misleading. Judge failures could be interpreted as routing misses, and the 150-character description truncation omitted important exclusion clauses.

This makes the contracts explicit:

- `make eval` / `make eval-all`: deterministic structural checks
- `make eval-full`: structural checks plus a fresh paid behavioral run
- `EVAL_USE_TRIGGER_CACHE=1`: explicit diagnostic opt-in for cached behavioral scoring

## Behavioral results

Fresh complete-catalog run with `claude-haiku-4-5`:

- 51/51 skills met the 75% minimum
- aggregate accuracy: 95.74%
- `pr-review`: 80%
- `testing`: 100%
- `full`: 91.67%
- `help`: 83.33%
- `examples`: 90%
- `intent-detection`: 100%

The first fresh sweep exposed `examples` and `intent-detection` at 70%; both descriptions were corrected generically and the final full sweep passed.

## Validation

- `make eval-full` — 51/51 behavioral gate passed, 95.74% aggregate
- `make ci` — passed
- `make test` — 220 passed
- `make generated-skills-sync` — all four targets, 51 skills each
- `make amp-runtime-smoke` — Amp `0.0.1784838101-ga3144b`, 51 skills
- `make codex-runtime-smoke` — Codex `0.145.0`, 51 skills
- `make pi-runtime-smoke` — Pi `0.81.1`, 51 skills
- `make opencode-runtime-smoke` — OpenCode `1.17.2`, 51 skills
- `git diff --check` — passed

## Stack

This is intentionally stacked on #109 because it includes the documentation corrections from that branch. After #109 merges, retarget this PR to `main`; the behavioral-eval commit itself is `daea640`.
