### PR TITLE
chore(release): prepare v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [3.0.0] - 2026-07-24
+
+Major release: keep Claude Code as the full canonical plugin while adding
+generated, runtime-native skills distributions for Amp, Codex, Pi, and
+OpenCode. Each target is explicit about supported workflows and deferred
+capabilities rather than claiming cross-runtime feature parity.
+
+### Added
+
+- **Generated multi-runtime skills distributions** — all 51 canonical skills,
+  complete resource subtrees, non-Markdown bytes, and executable modes now ship
+  as deterministic targets for Amp, Codex, Pi, and OpenCode. Target generators
+  normalize names and invocation syntax, validate references and manifests,
+  reject collisions and escaping resources, build through staging directories,
+  preserve prior output on failure, and provide read-only drift checks. Claude
+  Code remains the canonical source and retains its full native hooks, agents,
+  MCP, permissions, and instructions.
+
 - **Canonical multi-runtime support matrix** — documents native invocation,
   distribution, supported and deferred capabilities, generated-target
   acceptance requirements, and isolated Amp, Codex, Pi, and OpenCode smoke-test
@@ -84,6 +106,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   clarify that Amp copies skills and requires an explicit `--overwrite` install.
 
 ### Fixed
+
+- **Reliable behavioral trigger gates and routing boundaries** — deterministic
+  structural evals no longer depend on ignored local result caches, while
+  `make eval-full` runs a fresh Claude Haiku 4.5 gate requiring every skill to
+  reach 75% accuracy. The judge now receives complete descriptions, validates
+  the exact skill/fixture set, retries infrastructure failures, rejects malformed
+  output, and writes results atomically. Generalized routing fixes brought all
+  51 skills above the threshold in the final full run (95.74% aggregate).
 
 - **Generated-runtime install lifecycle guidance** — Amp now documents native,
   target-scoped removal and exact-sync boundaries; Pi distinguishes configured

--- a/README.md
+++ b/README.md
@@ -105,14 +105,13 @@ that prevent the mistakes Elixir developers actually make in production.
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-> **v2.14.3** -- the `ecto-patterns` skill now documents the
-> `Repo.transaction/1` changeset error-handling footgun: a bare
-> `{:ok, _} = Repo.update(cs)` inside the callback form raises `MatchError`,
-> which rolls back and **re-raises** — crashing the caller and losing the
-> changeset's validation errors. Covers the `case` + `Repo.rollback/1` and
-> `with ... else` fixes, and points at `Repo.transact/1` / `Ecto.Multi` as the
-> footgun-free forms. Thanks to [@ndrean](https://github.com/ndrean) for the
-> proposal.
+> **v3.0.0** -- all 51 canonical skills now have generated distributions for
+> Amp, Codex, Pi, and OpenCode, with deterministic generation, complete bundled
+> resources, drift enforcement, isolated runtime smoke tests, and native
+> installation guidance. Claude Code remains the full canonical plugin; hooks,
+> agents, MCP, instructions, and workflow portability intentionally vary by
+> runtime. See the [support matrix](docs/runtime-support.md) before assuming
+> feature parity.
 > [Issues](https://github.com/oliver-kriska/claude-elixir-phoenix/issues) welcome.
 
 ## Installation

--- a/plugins/elixir-phoenix/.claude-plugin/plugin.json
+++ b/plugins/elixir-phoenix/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elixir-phoenix",
-  "version": "2.14.3",
+  "version": "3.0.0",
   "description": "Elixir/Phoenix/LiveView development with specialist agents, Iron Laws, and Tidewave MCP integration",
   "keywords": ["elixir", "phoenix", "liveview", "ecto", "oban", "otp"],
   "author": {

--- a/scripts/generated_target_snapshots.json
+++ b/scripts/generated_target_snapshots.json
@@ -9,7 +9,7 @@
     "codex": {
       "entries": 385,
       "files": 254,
-      "sha256": "59a6aa21c856a3d848d2ca8ab56eb07985c2803de2cc839b82d016b9fe2058c3"
+      "sha256": "65a90a11512ca06e8f2fa29494fa9fa9c3574a028cbb2615b4480c8366953422"
     },
     "opencode": {
       "entries": 379,
@@ -19,7 +19,7 @@
     "pi": {
       "entries": 380,
       "files": 252,
-      "sha256": "2b4372f193aa6737246b9d0fbc4ed1baeac49922cbe7398014dd291f77de3eec"
+      "sha256": "f39232433c01597bd34a6d4c6b4c302469189bf33db940f17e810daf61270e5f"
     }
   }
 }

--- a/targets/codex/.codex-plugin/plugin.json
+++ b/targets/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "elixir-phoenix",
-  "version": "2.14.3",
+  "version": "3.0.0",
   "description": "Generated Elixir, Phoenix, LiveView, Ecto, Oban, testing, and security skills for Codex",
   "skills": "./skills/",
   "interface": {

--- a/targets/pi/package.json
+++ b/targets/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-elixir-phoenix",
-  "version": "2.14.3",
+  "version": "3.0.0",
   "description": "Generated Elixir, Phoenix, LiveView, Ecto, Oban, testing, and security skills for Pi",
   "keywords": [
     "elixir",


### PR DESCRIPTION
## Summary

Prepare the repository metadata and release notes for v3.0.0.

This is a stacked release-preparation PR:

- based on #111 (`fix/behavioral-eval-consistency`)
- #111 is based on #109 (`docs/post-runtime-accuracy-audit`)

It does not create a tag, publish a GitHub release, or claim feature parity across runtimes.

## Release positioning

Claude Code remains the canonical source and the runtime with full plugin support. Amp, Codex, Pi, and OpenCode receive generated, runtime-native skill distributions with the capabilities and limitations documented in `docs/runtime-support.md`.

This PR:

- bumps the canonical plugin manifest to 3.0.0
- propagates 3.0.0 to the generated Codex and Pi manifests
- updates generated-target golden snapshots
- adds the dated v3.0.0 CHANGELOG entry and restores an empty Unreleased scaffold
- updates the README release highlight without overstating runtime parity

## Verification

- `make ci` — passed (220 pytest tests, manifest validation, all generated-target drift checks, structural eval, security scan)
- `make generated-skills-sync` — passed (51 skills each for Amp, Codex, Pi, and OpenCode; snapshots clean)
- `make amp-runtime-smoke` — passed (Amp 0.0.1784838101-ga3144b, 51 skills)
- `make codex-runtime-smoke` — passed (Codex 0.145.0, 51 skills)
- `make pi-runtime-smoke` — passed (Pi 0.81.1, 51 skills)
- `make opencode-runtime-smoke` — passed (OpenCode 1.17.2, 51 skills)
- release metadata consistency check — canonical, Codex, Pi, and CHANGELOG all report 3.0.0

Inherited from #111's fresh full behavioral evaluation:

- 51/51 skills at or above the 75% gate
- 95.74% average routing accuracy
- judge: `claude-haiku-4-5`

## Publication guard

No `v3.0.0` tag or GitHub release has been created. Publication remains a separate, explicit action after #109, #111, and this preparation PR are reviewed and merged.
