### PR TITLE
fix(amp): use strict generated tree drift checks

### DIFF
--- a/scripts/build_amp_skills.py
+++ b/scripts/build_amp_skills.py
@@ -4,43 +4,19 @@
 from __future__ import annotations
 
 import argparse
-import filecmp
-import stat
 import sys
 import tempfile
 from pathlib import Path
 
 from .port_lib import SOURCE_PLUGIN_DIR, TARGETS_DIR
 from .port_lib import amp
+from .port_lib.generated_tree import tree_differences
 
 OUTPUT_DIR = TARGETS_DIR / "amp" / "skills"
 
 
 def _differences(expected: Path, actual: Path) -> list[str]:
-    differences: list[str] = []
-    comparison = filecmp.dircmp(expected, actual)
-
-    def walk(current: filecmp.dircmp, prefix: str = "") -> None:
-        differences.extend(
-            f"missing in target: {prefix}{name}" for name in current.left_only
-        )
-        differences.extend(
-            f"extra in target: {prefix}{name}" for name in current.right_only
-        )
-        for name in current.common_files:
-            left = Path(current.left) / name
-            right = Path(current.right) / name
-            if not filecmp.cmp(left, right, shallow=False):
-                differences.append(f"differs: {prefix}{name}")
-            elif stat.S_IMODE(left.stat().st_mode) != stat.S_IMODE(
-                right.stat().st_mode
-            ):
-                differences.append(f"mode differs: {prefix}{name}")
-        for name, child in current.subdirs.items():
-            walk(child, f"{prefix}{name}/")
-
-    walk(comparison)
-    return differences
+    return tree_differences(expected, actual)
 
 
 def check() -> int:

--- a/scripts/tests/test_amp.py
+++ b/scripts/tests/test_amp.py
@@ -191,6 +191,19 @@ def test_drift_comparison_detects_mode_only_changes(tmp_path) -> None:
     assert _differences(expected, actual) == ["mode differs: phx-one/run.sh"]
 
 
+def test_drift_comparison_detects_file_directory_type_changes(tmp_path) -> None:
+    expected = tmp_path / "expected"
+    actual = tmp_path / "actual"
+    expected.mkdir()
+    actual.mkdir()
+    (expected / "node").write_text("file\n", encoding="utf-8")
+    (actual / "node").mkdir()
+
+    assert _differences(expected, actual) == [
+        "type differs: node (file != directory)"
+    ]
+
+
 def test_build_restores_previous_target_when_installation_fails(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
## Summary

- delegate Amp drift comparison to the shared strict generated-tree comparator
- detect file/directory type substitutions and stop inheriting `filecmp.dircmp` ignore behavior
- add an Amp-specific type-change regression test

Addresses pre-release review finding #1.

## Verification

- targeted Amp/Codex generator tests: 39 passed
- `make ci`: 221 tests and all repository gates passed
- generated Amp output remains unchanged