### PR TITLE
fix(pi): align root package metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,11 @@ capabilities rather than claiming cross-runtime feature parity.
   rebuild workflow triggers on all five runtime guides instead of only
   `docs/amp.md`.
 
+- **Pi Git-package metadata now matches the generated distribution** — the
+  repository-root manifest used by the documented Pi installation reports the
+  same `pi-elixir-phoenix` name, 3.0.0 version, and Pi-focused description as
+  `targets/pi/package.json`.
+
 - **Reliable behavioral trigger gates and routing boundaries** — deterministic
   structural evals no longer depend on ignored local result caches, while
   `make eval-full` runs a fresh Claude Haiku 4.5 gate requiring every skill to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "elixir-phoenix-plugin",
-  "version": "1.0.0",
+  "name": "pi-elixir-phoenix",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "elixir-phoenix-plugin",
-      "version": "1.0.0",
+      "name": "pi-elixir-phoenix",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "husky": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "elixir-phoenix-plugin",
-  "version": "1.0.0",
+  "name": "pi-elixir-phoenix",
+  "version": "3.0.0",
   "private": true,
-  "description": "Claude Code plugin for Elixir/Phoenix development",
+  "description": "Generated Elixir, Phoenix, LiveView, Ecto, Oban, testing, and security skills for Pi",
   "keywords": [
     "pi-package"
   ],

--- a/scripts/tests/test_pi.py
+++ b/scripts/tests/test_pi.py
@@ -224,6 +224,9 @@ def test_repository_manifest_resources_and_flagship_overlays() -> None:
     assert "extensions" not in manifest["pi"]
     assert "pi-package" in manifest["keywords"]
     assert repository_manifest["pi"] == {"skills": ["./targets/pi/skills"]}
+    assert repository_manifest["name"] == manifest["name"]
+    assert repository_manifest["version"] == manifest["version"]
+    assert repository_manifest["description"] == manifest["description"]
     assert isinstance(repository_manifest["pi"]["skills"], list)
     assert (TARGETS_DIR.parent / repository_manifest["pi"]["skills"][0]).is_dir()
     assert pi.validate(target) == 51


### PR DESCRIPTION
## Summary

- align the repository-root Pi package name, version, and description with `targets/pi/package.json`
- update the package-lock root metadata
- enforce root/generated Pi metadata consistency in tests

Addresses pre-release review finding #2. This PR is stacked on #114 because both intentionally update the root package manifest.

## Verification

- Pi generator tests: 9 passed
- `make pi-runtime-smoke`: Pi 0.81.1, 51 skills
- root, lock, and generated metadata consistency check passed
- `make ci`: 220 tests and all repository gates passed