### PR TITLE
fix(port): clarify runtime support and hook requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,12 @@ capabilities rather than claiming cross-runtime feature parity.
   skill tree, and transformed Markdown permissions no longer depend on the
   invoking process's umask.
 
+- **Runtime support and security claims now match operational boundaries** —
+  the flagship portability contract is scoped to adapted Codex, Pi, and
+  OpenCode workflows; Codex documents and surfaces its Bash/`jq` hook
+  prerequisites; and security documentation distinguishes absent telemetry or
+  covert egress from visible, user-authorized external service calls.
+
 - **Reliable behavioral trigger gates and routing boundaries** — deterministic
   structural evals no longer depend on ignored local result caches, while
   `make eval-full` runs a fresh Claude Haiku 4.5 gate requiring every skill to

--- a/README.md
+++ b/README.md
@@ -805,15 +805,17 @@ This plugin runs skills, agents, and hooks inside Claude Code with your tool
 permissions, so it ships a verifiable security posture:
 
 - **Independently scanned** with [NVIDIA SkillSpector](https://github.com/NVIDIA/SkillSpector)
-  (static analysis, **zero data egress**): **66 / 77 components SAFE**, 7 CAUTION,
+  (static analysis, **zero covert-egress findings**): **66 / 77 components SAFE**, 7 CAUTION,
   4 DO_NOT_INSTALL raw. The four DO_NOT_INSTALL components are documented false
   positives with reviewed baselines, so **after baselines 0 remain and the scan
   gate passes** (the 7 CAUTION-tier components stay documented). A static scanner
   flags the *safety-enforcing* and *security-auditing* skills precisely because
   they name dangerous patterns in order to forbid or detect them (e.g. the line
   literally reads `NEVER bypass security checks for speed`).
-- **No data exfiltration**, **read-only review agents** (source edits disallowed),
-  and **auditable bash hooks** you can read in `plugins/elixir-phoenix/hooks/`.
+- **No telemetry or covert egress**; workflows can make visible, user-authorized
+  GitHub, Hex, web-search, or configured MCP calls through the host runtime.
+  Review agents are read-only by default (source edits disallowed), and the
+  Bash hooks are auditable in `plugins/elixir-phoenix/hooks/`.
 
 Full report, line-by-line triage, and a reproduce-it-yourself command live in
 **[SECURITY.md](SECURITY.md)**. Re-run the scan anytime with `make security`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -85,9 +85,10 @@ the table.
 
 ## What this plugin does and doesn't do
 
-- **No data exfiltration.** Nothing in the plugin transmits your code or
-  conversation to an external service. Skills and agents are Markdown
-  instructions; hooks are local shell scripts.
+- **No telemetry or covert egress.** Skills and agents are Markdown
+  instructions and hooks are local shell scripts. Some workflows may invoke
+  visible, user-authorized external services such as GitHub, Hex, web search,
+  or configured MCP servers through the host runtime's normal permission model.
 - **Hooks are auditable bash.** They format Elixir, verify Iron Laws, and block
   destructive ops (`mix ecto.reset`, `git push --force`, `MIX_ENV=prod`). Read
   them in [`plugins/elixir-phoenix/hooks/`](plugins/elixir-phoenix/hooks/).

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -109,7 +109,8 @@ may not be fully portable.
 ## Optional Native Safety Hook
 
 The generated plugin includes one synchronous `PreToolUse` command hook for
-Codex's `Bash` tool. It blocks:
+Codex's `Bash` tool. The safeguard requires a Unix-like host with Bash and
+`jq`; no Windows command is currently included. It blocks:
 
 - `mix ecto.reset` and `mix ecto.drop` in Elixir projects;
 - unguarded `git push --force` / `git push -f` while allowing
@@ -120,6 +121,9 @@ Codex discovers plugin hooks but does not silently trust them. Review and enable
 the hook through `/hooks`; if it is untrusted, disabled, or disallowed by policy,
 all skills still work. Plugin updates that change the hook may require another
 trust review. Do not use `--dangerously-bypass-hook-trust` for normal sessions.
+The hook intentionally fails open: when Bash cannot execute it, protection is
+unavailable; when `jq` is missing, the hook prints a disabled warning and allows
+the command rather than acting as a partial security boundary.
 
 Only this audited synchronous safeguard is projected. The canonical Claude hook
 file contains runtime-specific conditions, events, and asynchronous handlers

--- a/docs/runtime-support.md
+++ b/docs/runtime-support.md
@@ -44,8 +44,11 @@ installation and troubleshooting remain in the linked guides.
 | Isolated native smoke command | Not applicable | Yes | Yes | Yes | Yes |
 
 “External” Tidewave support means a skill may use Tidewave when the project and
-runtime already expose it. Generated flagship workflows must still complete
-without Tidewave, named custom agents, or Claude-only task APIs.
+runtime already expose it. Adapted Codex, Pi, and OpenCode flagship workflows
+must still complete without Tidewave, named custom agents, or Claude-only task
+APIs. Amp ships generated guidance for those workflows; its Claude-specific
+orchestration steps require the Amp-native adaptation documented in the
+[Amp guide](amp.md#feature-compatibility).
 
 ## Native invocation and installation
 

--- a/plugins/elixir-phoenix/hooks/scripts/block-dangerous-ops.sh
+++ b/plugins/elixir-phoenix/hooks/scripts/block-dangerous-ops.sh
@@ -14,6 +14,12 @@
 # blocked ALL Bash calls), so hooks.json appends `|| exit 0` to fail open.
 # Never add a deny path that relies on a non-zero exit code.
 
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%s\n' \
+    'elixir-phoenix safety hook disabled: jq is unavailable (failing open).' >&2
+  exit 0
+fi
+
 INPUT=$(cat)
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 [[ "$TOOL" == "Bash" ]] || exit 0

--- a/scripts/generated_target_snapshots.json
+++ b/scripts/generated_target_snapshots.json
@@ -9,7 +9,7 @@
     "codex": {
       "entries": 385,
       "files": 254,
-      "sha256": "7d3384f5164dea6204d76229eeb42654d6352151784714452d8973ff10879d85"
+      "sha256": "103a2fb6bf2c852d1b0814fce61a0439cf21edbfc4954fb83bcec0f3cdd3bb1e"
     },
     "opencode": {
       "entries": 379,

--- a/scripts/tests/test_codex.py
+++ b/scripts/tests/test_codex.py
@@ -504,6 +504,23 @@ def test_repository_hook_is_native_synchronous_and_projects_source(tmp_path) -> 
     )
     assert failed_open.stdout == ""
 
+    bin_dir = tmp_path / "bin-without-jq"
+    bin_dir.mkdir()
+    (bin_dir / "bash").symlink_to(shutil.which("bash") or "/bin/bash")
+    missing_jq = subprocess.run(
+        [str(generated)],
+        input=json.dumps(
+            {"tool_name": "Bash", "tool_input": {"command": "mix ecto.reset"}}
+        ),
+        text=True,
+        capture_output=True,
+        cwd=fixture,
+        env={**os.environ, "PATH": str(bin_dir)},
+        check=True,
+    )
+    assert missing_jq.stdout == ""
+    assert "safety hook disabled: jq is unavailable" in missing_jq.stderr
+
 
 def test_flagship_overlays_are_anchored_and_remove_claude_runtime_dependencies() -> None:
     target = TARGETS_DIR / "codex" / "skills"

--- a/targets/codex/hooks/scripts/block-dangerous-ops.sh
+++ b/targets/codex/hooks/scripts/block-dangerous-ops.sh
@@ -14,6 +14,12 @@
 # blocked ALL Bash calls), so hooks.json appends `|| exit 0` to fail open.
 # Never add a deny path that relies on a non-zero exit code.
 
+if ! command -v jq >/dev/null 2>&1; then
+  printf '%s\n' \
+    'elixir-phoenix safety hook disabled: jq is unavailable (failing open).' >&2
+  exit 0
+fi
+
 INPUT=$(cat)
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 [[ "$TOOL" == "Bash" ]] || exit 0


### PR DESCRIPTION
## Summary

- scope the no-Claude-task-API flagship guarantee to the explicitly adapted Codex, Pi, and OpenCode targets; Amp remains generated guidance pending native orchestration overlays
- make a missing `jq` dependency visible when the optional Codex safety hook intentionally fails open, and document its Unix/Bash/`jq` and Windows limitations
- replace absolute no-egress claims with the accurate guarantee: no telemetry or covert egress, while workflows may make visible user-authorized external calls

This PR is stacked on #113 because it includes that branch’s generated-link fixes. It addresses pre-release review findings 3, 4, and 5. It does not add Amp workflow overlays and does not create a tag or release.

## Verification

- `make ci` — 220 tests passed; manifests, all four generated targets, snapshots, evals, and security scan passed
- `make generated-skills-sync` — 51 skills on Amp, Codex, Pi, and OpenCode
- `python3 -m pytest scripts/tests/test_codex.py -q` — 28 passed
- `make codex-runtime-smoke` — Codex 0.145.0 discovered 51 skills
- `git diff --check`