### PR TITLE
fix(codex): preserve dependency vetting route metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,10 @@ capabilities rather than claiming cross-runtime feature parity.
   prerequisites; and security documentation distinguishes absent telemetry or
   covert egress from visible, user-authorized external service calls.
 
+- **Codex dependency-vetting routing metadata stays complete** — the generated
+  `phx-deps-vet` description now preserves both its post-audit trigger and its
+  distinction from dependency scanning instead of ending mid-clause.
+
 - **Reliable behavioral trigger gates and routing boundaries** — deterministic
   structural evals no longer depend on ignored local result caches, while
   `make eval-full` runs a fresh Claude Haiku 4.5 gate requiring every skill to

--- a/scripts/generated_target_snapshots.json
+++ b/scripts/generated_target_snapshots.json
@@ -9,7 +9,7 @@
     "codex": {
       "entries": 385,
       "files": 254,
-      "sha256": "103a2fb6bf2c852d1b0814fce61a0439cf21edbfc4954fb83bcec0f3cdd3bb1e"
+      "sha256": "cf9a3d3dac4664155a532d44ce8803ef2a18f7585e8de6f7c71d24d0c5b99a20"
     },
     "opencode": {
       "entries": 379,

--- a/scripts/port_lib/codex.py
+++ b/scripts/port_lib/codex.py
@@ -79,6 +79,10 @@ CODEX_SKILL_DESCRIPTION_OVERRIDES = {
         "Update Hex dependencies safely. Use for upgrades; use "
         "$phx-investigate for deps.get failures."
     ),
+    "phx-deps-vet": (
+        "Record vetted Hex versions after security review. Use to approve audited "
+        "dependencies, not to scan them."
+    ),
     "phx-document": (
         "Write Elixir @moduledoc and @doc text. Use only for code documentation, not "
         "README or external docs."

--- a/scripts/tests/test_codex.py
+++ b/scripts/tests/test_codex.py
@@ -189,6 +189,7 @@ def test_namespace_expansion_wraps_only_affected_prose() -> None:
             "phx-deps-update",
             "$elixir-phoenix:phx-investigate for deps.get failures",
         ),
+        ("phx-deps-vet", "not to scan them"),
         ("phx-document", "not README or external docs"),
         ("phx-full", "$elixir-phoenix:phx-work for an existing plan"),
         ("phx-help", "not for Codex /help"),

--- a/targets/codex/skills/phx-deps-vet/SKILL.md
+++ b/targets/codex/skills/phx-deps-vet/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: phx-deps-vet
-description: Record a vetted Hex package version in hex_vet.exs after a security;
-  Use to approve a dep…
+description: Record vetted Hex versions after security review. Use to approve audited
+  dependencies, not to scan them.
 ---
 
 # Deps Vet — Hex package audit ledger


### PR DESCRIPTION
## Summary

- replace the malformed generated `phx-deps-vet` description with an intentional compact override
- preserve its post-security-review trigger and its boundary from dependency scanning
- add the skill to the route-sensitive description regression matrix and regenerate Codex output/snapshots

This PR is stacked on #119. The targeted override is intentionally preferred over changing the generic compactor and risking unrelated routing metadata immediately before v3.0.0. No tag or release is created.

## Verification

- `make ci` — 221 tests passed; all generation, drift, eval, and security gates passed
- `python3 -m pytest scripts/tests/test_codex.py -q` — 29 passed
- `python3 -m lab.eval.trigger_scorer --skill deps-vet --summary` — 92% accuracy, 88% precision, 100% recall
- `make codex-runtime-smoke` — Codex 0.145.0 discovered 51 skills
- `make generated-skills-sync` — all four generated targets clean
- `git diff --check`