### PR TITLE
fix(amp): harden generated resource projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ capabilities rather than claiming cross-runtime feature parity.
   same `pi-elixir-phoenix` name, 3.0.0 version, and Pi-focused description as
   `targets/pi/package.json`.
 
+- **Amp generation now rejects source symlinks and preserves Markdown modes** —
+  generated resources can no longer dereference links outside the canonical
+  skill tree, and transformed Markdown permissions no longer depend on the
+  invoking process's umask.
+
 - **Reliable behavioral trigger gates and routing boundaries** — deterministic
   structural evals no longer depend on ignored local result caches, while
   `make eval-full` runs a fresh Claude Haiku 4.5 gate requiring every skill to

--- a/scripts/port_lib/amp.py
+++ b/scripts/port_lib/amp.py
@@ -49,6 +49,14 @@ def discover_skills(source_plugin_dir: str | Path) -> list[SkillSource]:
     """Read all canonical skills and reject invalid or colliding target names."""
     plugin_dir = Path(source_plugin_dir)
     skills_dir = plugin_dir / "skills"
+    if skills_dir.is_symlink() or not skills_dir.is_dir():
+        raise ValueError(f"{skills_dir}: canonical skills must be a real directory")
+    for source_path in sorted(skills_dir.rglob("*")):
+        if source_path.is_symlink():
+            raise ValueError(f"{source_path}: symlinks are not supported in skills")
+        if not source_path.is_dir() and not source_path.is_file():
+            raise ValueError(f"{source_path}: special files are not supported in skills")
+
     discovered: list[SkillSource] = []
     names: dict[str, Path] = {}
 
@@ -215,7 +223,6 @@ def _populate(skills: list[SkillSource], output_dir: Path) -> None:
         output_dir,
         IGNORED_FILES,
         _transform_markdown,
-        preserve_markdown_mode=False,
     )
 
 

--- a/scripts/tests/test_amp.py
+++ b/scripts/tests/test_amp.py
@@ -61,6 +61,7 @@ def test_build_copies_complete_subtree_and_transforms_only_markdown(tmp_path) ->
     references = skill / "references"
     references.mkdir()
     (references / "guide.md").write_text("Use /phx:source.\n", encoding="utf-8")
+    (references / "guide.md").chmod(0o744)
     payload = b"\x00\xff\x10"
     (skill / "nested" / "assets").mkdir(parents=True)
     (skill / "nested" / "assets" / "payload.bin").write_bytes(payload)
@@ -78,6 +79,7 @@ def test_build_copies_complete_subtree_and_transforms_only_markdown(tmp_path) ->
         in (references := generated / "references" / "guide.md").read_text()
     )
     assert "/phx:source" not in references.read_text()
+    assert stat.S_IMODE(references.stat().st_mode) == 0o744
     assert (generated / "nested" / "assets" / "payload.bin").read_bytes() == payload
     assert stat.S_IMODE((generated / "nested" / "run.sh").stat().st_mode) == 0o755
 
@@ -161,6 +163,23 @@ def test_build_reports_missing_resource_with_source_path(tmp_path) -> None:
 
     with pytest.raises(ValueError, match=str(skill / "SKILL.md")):
         amp.build(plugin, tmp_path / "output")
+
+
+def test_build_rejects_symlinked_resources_without_replacing_target(tmp_path) -> None:
+    plugin = tmp_path / "plugin"
+    skill = _write_skill(plugin, "source", "phx:source")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("private\n", encoding="utf-8")
+    (skill / "linked.txt").symlink_to(outside)
+    output = tmp_path / "output"
+    output.mkdir()
+    sentinel = output / "keep.txt"
+    sentinel.write_text("unchanged\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="linked.txt.*symlinks are not supported"):
+        amp.build(plugin, output)
+
+    assert sentinel.read_text(encoding="utf-8") == "unchanged\n"
 
 
 def test_amp_projection_is_deterministic(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- reject canonical Amp skill trees containing symlinks or special filesystem nodes before generation
- preserve source Markdown modes after transformation instead of inheriting the process umask
- verify symlink rejection leaves the existing target intact and transformed Markdown keeps its source mode

This PR is stacked on #117. Regenerating all targets produced no tracked generated-output or snapshot changes, proving the current Amp target remains byte- and mode-identical. No tag or release is created.

## Verification

- `make ci` — 222 tests passed; all generation, drift, eval, and security gates passed
- `python3 -m pytest scripts/tests/test_amp.py -q` — 12 passed
- `make generated-skills-sync` — all four generated targets clean
- `make amp-runtime-smoke` — Amp 0.0.1784869297-gd5f395 discovered 51 skills
- regeneration left `targets/amp` and snapshots unchanged
- `git diff --check`