### PR TITLE
fix(tidewave): correct MCP setup guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,11 @@ capabilities rather than claiming cross-runtime feature parity.
 
 ### Fixed
 
+- **Accurate Tidewave MCP setup boundary** — update the maintained Phoenix
+  dependency requirement and repository link, distinguish exposing Tidewave's
+  HTTP server from registering it with a client, and document external
+  registration for Claude Code, Codex, and OpenCode.
+
 - **Generated nested resource links now resolve from their containing file** —
   Amp, Codex, Pi, and OpenCode projections compute skill-relative paths from
   each Markdown resource directory instead of the skill root, fixing broken

--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ Code plugin.
 including `$elixir-phoenix:phx-investigate` and
 `$elixir-phoenix:phx-review` workflows. See
 [Use with Codex](#use-with-codex); a trust-gated destructive-command safeguard
-is included, while custom agents and bundled Tidewave MCP are intentionally not
-included yet.
+is included, while custom agents are intentionally not included and Tidewave
+MCP registration remains external.
 
 **Using Pi?** Install the native generated skills package for all 51 skills,
 including Pi-compatible `/skill:phx-investigate` and `/skill:phx-review`
 workflows. See [Use with Pi](#use-with-pi); extensions, prompt templates, MCP,
-and custom agents are intentionally not included yet.
+and custom agents are intentionally not included yet. Tidewave can be used when
+the Pi host exposes it independently.
 
 **Using OpenCode?** Install the generated skills-only target for all 51 skills,
 including `phx-investigate` and `phx-review`. In the tested OpenCode 1.17.2 setup,
@@ -100,7 +101,7 @@ that prevent the mistakes Elixir developers actually make in production.
 │    web-researcher (haiku)          progress-tracking · block-danger │
 │                                                                     │
 │  ───────────────────────────────────────────────────────────        │
-│  26 Iron Laws · Tidewave MCP · plan→work→verify→review→compound     │
+│  26 Iron Laws · Tidewave-aware · plan→work→verify→review→compound   │
 │  github.com/oliver-kriska/claude-elixir-phoenix                     │
 └─────────────────────────────────────────────────────────────────────┘
 ```
@@ -231,9 +232,9 @@ alias. This edition also ships one synchronous native hook that blocks destructi
 Ecto resets/drops, unguarded force pushes, and accidental `MIX_ENV=prod mix`
 commands. Codex requires users to review and trust plugin hooks before they run;
 the skills work without it. Custom agents, plugin-root instructions, the remaining
-Claude hooks, and Tidewave MCP remain deferred. See the complete
-[Codex guide](docs/codex.md) for updates, uninstall, isolation, troubleshooting,
-tested version, and capability details.
+Claude hooks remain deferred; Tidewave MCP registration is external. See the
+complete [Codex guide](docs/codex.md) for updates, uninstall, isolation,
+troubleshooting, tested version, and capability details.
 
 ### Use with Pi
 
@@ -249,9 +250,9 @@ Start a fresh Pi session, then invoke workflows explicitly with
 `/skill:phx-investigate` or `/skill:phx-review`. Pi can also select a skill from
 its description automatically. This edition ships skills and their complete
 bundled resources only—not extensions, prompt templates, custom agents,
-package-root instructions, or Tidewave MCP configuration. See the complete
-[Pi guide](docs/pi.md) for project-local installation, updates, uninstall,
-isolation, troubleshooting, tested version, and capability details.
+or package-root instructions. Tidewave MCP registration is external. See the
+complete [Pi guide](docs/pi.md) for project-local installation, updates,
+uninstall, isolation, troubleshooting, tested version, and capability details.
 
 ### Use with OpenCode
 
@@ -268,12 +269,12 @@ phx-investigate skill, then …”. In the tested OpenCode 1.17.2 setup,
 `/phx-investigate` and `/phx-review` also work when they do not collide with
 existing commands, but the skill tool is the documented portable interface. OpenCode
 selects the model implicitly. This target contains skills and complete bundled
-resources only—not hooks, custom agents, or Tidewave MCP configuration.
-Investigation, review, plan, work, PR-review, and full-lifecycle workflows are
-explicitly adapted; some other skills may still describe optional
-Claude-specific orchestration APIs. See the [OpenCode installation and
-support guide](docs/opencode.md) for global setup, updates, uninstall,
-feature-branch review, discovery debugging, and limitations.
+resources only—not hooks or custom agents. Tidewave MCP registration is
+external. Investigation, review, plan, work, PR-review, and full-lifecycle
+workflows are explicitly adapted; some other skills may still describe optional
+Claude-specific orchestration APIs. See the
+[OpenCode installation and support guide](docs/opencode.md) for global setup,
+updates, uninstall, feature-branch review, discovery debugging, and limitations.
 
 ## Getting Started
 
@@ -771,17 +772,30 @@ These load automatically based on file context -- no commands needed:
 
 ## Tidewave MCP Integration
 
-When your Phoenix app runs with [Tidewave](https://github.com/tidewave-elixir/tidewave), the plugin automatically detects it and uses runtime tools:
+When your Phoenix app runs with
+[Tidewave](https://github.com/tidewave-ai/tidewave_phoenix), the plugin detects
+the local server and prefers its runtime tools. Add Tidewave to the application:
 
 ```elixir
 # Add to mix.exs
-{:tidewave, "~> 0.1", only: :dev}
+{:tidewave, "~> 0.6", only: :dev}
 
 # Add to endpoint.ex (in dev block)
 plug Tidewave
 ```
 
-Available runtime tools: execute Elixir code, run SQL queries, get docs for your exact dependency versions, introspect Ecto schemas, read application logs.
+Then register the running endpoint with Claude Code, replacing `$PORT` with the
+Phoenix port:
+
+```bash
+claude mcp add --transport http tidewave \
+  http://localhost:$PORT/tidewave/mcp
+```
+
+Use `/mcp` to verify the connection. The plugin does not silently register a
+fixed-port MCP endpoint. Once connected, Tidewave can execute Elixir code, run
+SQL queries, get documentation for exact dependency versions, introspect Ecto
+schemas, and read application logs.
 
 ## Requirements
 
@@ -932,7 +946,7 @@ This plugin was built with insights from these articles, repositories, and tools
 
 ### Repositories and Tools
 
-- <https://github.com/tidewave-elixir/tidewave>
+- <https://github.com/tidewave-ai/tidewave_phoenix>
 - <https://github.com/neilberkman/ccrider>
 - <https://github.com/nicobailon/visual-explainer>
 - <https://github.com/VoltAgent/awesome-claude-code-subagents>

--- a/docs/amp.md
+++ b/docs/amp.md
@@ -252,7 +252,7 @@ when a release deletes or renames a skill.
 | Parallel workflow orchestration | Full | Optional native workers with sequential fallback |
 | Lifecycle and enforcement hooks | Full | Not installed |
 | Claude permission settings | Full | Not installed |
-| Plugin MCP configuration | Full | Not installed |
+| Tidewave MCP connection | User-configured | User-configured |
 
 Domain and reference skills such as `liveview-patterns`, `ecto-patterns`,
 `testing`, and `security` work directly. The flagship `phx-investigate`,

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -106,6 +106,20 @@ read-only review → compound lifecycle by invoking portable skills or executing
 them sequentially in-session. Other workflows remain baseline projections and
 may not be fully portable.
 
+### Optional Tidewave MCP
+
+Installing this plugin does not register a Tidewave endpoint. When the Phoenix
+project already runs Tidewave, register its actual port separately:
+
+```bash
+codex mcp add tidewave --url http://localhost:$PORT/tidewave/mcp
+codex mcp list
+```
+
+Start Codex and use `/mcp` to verify that the Tidewave tools are connected;
+`codex mcp list` confirms configuration only. Generated workflows retain a
+complete fallback when Tidewave is unavailable.
+
 ## Optional Native Safety Hook
 
 The generated plugin includes one synchronous `PreToolUse` command hook for
@@ -200,7 +214,7 @@ Intentionally deferred:
 
 - the remaining Claude Code hooks, including async and unsupported events;
 - generated or automatically installed custom-agent TOMLs;
-- bundled Tidewave MCP configuration;
+- automatic Tidewave MCP registration;
 - plugin-root `AGENTS.md` or copied `CLAUDE.md` instructions;
 - exact Claude slash-command syntax such as `/phx:review`.
 

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -70,7 +70,7 @@ when their names do not collide with existing commands; the documented
 skill-tool prompt above is the portable explicit invocation.
 Native OpenCode subagents are an optional optimization in the flagship
 workflows, and the sequential fallback is valid. Tidewave is optional and its
-MCP setup is deferred. Exact Claude colon syntax such as `/phx:review` is not
+MCP registration is external. Exact Claude colon syntax such as `/phx:review` is not
 registered; use `/phx-review`. The investigation, review, plan, work, PR-review,
 and full-lifecycle workflows have explicit OpenCode adaptations. PR review uses a
 GitHub connector or authenticated `gh` without fabricating mutations; full
@@ -80,6 +80,26 @@ artifact schema and a scratchpad research checklist; work uses plan checkboxes a
 receive portable frontmatter, resource, and command projection but may still
 describe optional Claude-specific orchestration APIs; those capabilities are
 deferred rather than silently emulated.
+
+### Optional Tidewave MCP
+
+Installing these skills does not configure MCP. When the Phoenix project runs
+Tidewave, add its endpoint to the project `opencode.json` (or the global
+`~/.config/opencode/opencode.json`) and replace `$PORT`:
+
+```json
+{
+  "mcp": {
+    "tidewave": {
+      "type": "remote",
+      "url": "http://localhost:$PORT/tidewave/mcp",
+      "enabled": true
+    }
+  }
+}
+```
+
+Generated workflows retain a complete fallback when Tidewave is unavailable.
 
 ## Runtime acceptance
 

--- a/docs/pi.md
+++ b/docs/pi.md
@@ -102,7 +102,7 @@ Start a fresh Pi process after an install, update, ref change, or removal.
 - Pi extensions or hook-like event handlers;
 - generated prompt templates and short `/phx-*` aliases;
 - custom agents or subagent orchestration;
-- bundled Tidewave MCP configuration (Pi does not natively bundle MCP);
+- automatic Tidewave MCP registration (Pi does not natively bundle MCP);
 - package-root `AGENTS.md` or other automatic instructions;
 - exact Claude `/phx:*` command syntax.
 

--- a/docs/runtime-support.md
+++ b/docs/runtime-support.md
@@ -36,7 +36,7 @@ installation and troubleshooting remain in the linked guides.
 | Claude namespaced slash commands | Full | Not applicable | Not applicable | Not applicable | Not applicable |
 | Bundled custom agents | Full | Deferred | Deferred | Deferred | Deferred |
 | Lifecycle/enforcement hooks | Full | Deferred | One optional safeguard | Deferred | Deferred |
-| Bundled Tidewave MCP setup | Full | External | External | External | External |
+| Tidewave MCP connection | External | External | External | External | External |
 | Plugin-root instructions | Full | Deferred | Deferred | Deferred | Deferred |
 | Deterministic generated target | Canonical source | Yes | Yes | Yes | Yes |
 | Mode-aware CI drift validation | Not applicable | Yes | Yes | Yes | Yes |
@@ -44,9 +44,10 @@ installation and troubleshooting remain in the linked guides.
 | Isolated native smoke command | Not applicable | Yes | Yes | Yes | Yes |
 
 “External” Tidewave support means a skill may use Tidewave when the project and
-runtime already exposes it. Adapted flagship workflows in every generated target
-must still complete without Tidewave, named custom agents, or Claude-only task
-APIs.
+runtime already expose it. Installing Tidewave in a Phoenix app starts the MCP
+server but does not register its project-specific URL with any client. Adapted
+flagship workflows in every generated target must still complete without
+Tidewave, named custom agents, or Claude-only task APIs.
 
 ## Native invocation and installation
 
@@ -78,7 +79,8 @@ The local acceptance run recorded on 2026-07-23 used Amp
 
 `plugins/elixir-phoenix/` is the source of truth and retains the complete
 plugin: skills, commands, agents, hooks, root instructions, permission settings,
-and Tidewave MCP integration. Portability fixes must not weaken this behavior.
+and Tidewave-aware workflows. Users register the Tidewave MCP endpoint for each
+project and port. Portability fixes must not weaken this behavior.
 
 ### Amp
 
@@ -94,15 +96,16 @@ and explicit skill references use the `elixir-phoenix:` plugin namespace.
 Plugin-root agent definitions and `AGENTS.md` are not automatically activated.
 The plugin includes one optional, synchronous, trust-gated safeguard for
 destructive shell commands. The remaining Claude hooks, generated agent TOMLs,
-and bundled MCP configuration are separate future capabilities rather than
-hidden installation side effects.
+and plugin-root instructions are separate future capabilities rather than
+hidden installation side effects. Tidewave MCP registration remains external.
 
 ### Pi
 
 Pi consumes `targets/pi/skills` through the repository's Pi package declaration.
 Generated references use native `/skill:<name>` syntax. Extensions, prompt
 templates, custom-agent orchestration, package-root instructions, and bundled
-MCP configuration are deferred.
+MCP configuration are not installed. Tidewave remains optional when exposed by
+the host independently.
 
 ### OpenCode
 

--- a/plugins/elixir-phoenix/skills/tidewave-integration/SKILL.md
+++ b/plugins/elixir-phoenix/skills/tidewave-integration/SKILL.md
@@ -69,7 +69,7 @@ pid = pid("0.1234.0")
 
 ```elixir
 # mix.exs
-{:tidewave, "~> 0.1", only: :dev}
+{:tidewave, "~> 0.6", only: :dev}
 
 # endpoint.ex (in dev block)
 plug Tidewave
@@ -79,6 +79,11 @@ config :phoenix_live_view,
   debug_heex_annotations: true,
   debug_attributes: true
 ```
+
+The dependency and endpoint plug expose Tidewave's streamable HTTP server; they
+do not register it with an MCP client. Configure the current runtime separately
+with `http://localhost:<port>/tidewave/mcp`, then verify that Tidewave tools are
+available before relying on this skill.
 
 ## Reliability Guards
 

--- a/scripts/generated_target_snapshots.json
+++ b/scripts/generated_target_snapshots.json
@@ -4,22 +4,22 @@
     "amp": {
       "entries": 379,
       "files": 251,
-      "sha256": "14a574880dc09c448741510f97e5be3a15869f60e2efbe04212714eb8f085c21"
+      "sha256": "cb6a02faf8c3bc2e4c304eacdd026ae41d69c0d6d3b0449a8ca3b00ba0b94301"
     },
     "codex": {
       "entries": 385,
       "files": 254,
-      "sha256": "834ab217d2cf74abb45d178cf59dcdea0770bdbfd112bc4fe8f84ed3af502c27"
+      "sha256": "189c194d9d1ed017f6d4b7a59a944b1eb897e4830aed6b2c477f0b2cb10091ea"
     },
     "opencode": {
       "entries": 379,
       "files": 251,
-      "sha256": "60b6b0f029122629b337081aae1a2314e0ff0a2d0151aef4f7df95fbea13f1b1"
+      "sha256": "eba056e8756e17b4b8d126b1c815099501dd04229d517ee7b2c5bb0de942521f"
     },
     "pi": {
       "entries": 380,
       "files": 252,
-      "sha256": "1c198c21e44b42b59d6f9e34f4d29e3460bee86102e450db822d99ddee524595"
+      "sha256": "6d6478f1aaacbfe2481e1392329cf6239fcb0e7a01739e43e08e69096c1d349d"
     }
   }
 }

--- a/targets/amp/skills/tidewave-integration/SKILL.md
+++ b/targets/amp/skills/tidewave-integration/SKILL.md
@@ -68,7 +68,7 @@ pid = pid("0.1234.0")
 
 ```elixir
 # mix.exs
-{:tidewave, "~> 0.1", only: :dev}
+{:tidewave, "~> 0.6", only: :dev}
 
 # endpoint.ex (in dev block)
 plug Tidewave
@@ -78,6 +78,11 @@ config :phoenix_live_view,
   debug_heex_annotations: true,
   debug_attributes: true
 ```
+
+The dependency and endpoint plug expose Tidewave's streamable HTTP server; they
+do not register it with an MCP client. Configure the current runtime separately
+with `http://localhost:<port>/tidewave/mcp`, then verify that Tidewave tools are
+available before relying on this skill.
 
 ## Reliability Guards
 

--- a/targets/codex/skills/tidewave-integration/SKILL.md
+++ b/targets/codex/skills/tidewave-integration/SKILL.md
@@ -68,7 +68,7 @@ pid = pid("0.1234.0")
 
 ```elixir
 # mix.exs
-{:tidewave, "~> 0.1", only: :dev}
+{:tidewave, "~> 0.6", only: :dev}
 
 # endpoint.ex (in dev block)
 plug Tidewave
@@ -78,6 +78,11 @@ config :phoenix_live_view,
   debug_heex_annotations: true,
   debug_attributes: true
 ```
+
+The dependency and endpoint plug expose Tidewave's streamable HTTP server; they
+do not register it with an MCP client. Configure the current runtime separately
+with `http://localhost:<port>/tidewave/mcp`, then verify that Tidewave tools are
+available before relying on this skill.
 
 ## Reliability Guards
 

--- a/targets/opencode/skills/tidewave-integration/SKILL.md
+++ b/targets/opencode/skills/tidewave-integration/SKILL.md
@@ -68,7 +68,7 @@ pid = pid("0.1234.0")
 
 ```elixir
 # mix.exs
-{:tidewave, "~> 0.1", only: :dev}
+{:tidewave, "~> 0.6", only: :dev}
 
 # endpoint.ex (in dev block)
 plug Tidewave
@@ -78,6 +78,11 @@ config :phoenix_live_view,
   debug_heex_annotations: true,
   debug_attributes: true
 ```
+
+The dependency and endpoint plug expose Tidewave's streamable HTTP server; they
+do not register it with an MCP client. Configure the current runtime separately
+with `http://localhost:<port>/tidewave/mcp`, then verify that Tidewave tools are
+available before relying on this skill.
 
 ## Reliability Guards
 

--- a/targets/pi/skills/tidewave-integration/SKILL.md
+++ b/targets/pi/skills/tidewave-integration/SKILL.md
@@ -68,7 +68,7 @@ pid = pid("0.1234.0")
 
 ```elixir
 # mix.exs
-{:tidewave, "~> 0.1", only: :dev}
+{:tidewave, "~> 0.6", only: :dev}
 
 # endpoint.ex (in dev block)
 plug Tidewave
@@ -78,6 +78,11 @@ config :phoenix_live_view,
   debug_heex_annotations: true,
   debug_attributes: true
 ```
+
+The dependency and endpoint plug expose Tidewave's streamable HTTP server; they
+do not register it with an MCP client. Configure the current runtime separately
+with `http://localhost:<port>/tidewave/mcp`, then verify that Tidewave tools are
+available before relying on this skill.
 
 ## Reliability Guards
 


### PR DESCRIPTION
## Summary

Corrects Tidewave setup guidance before v3.0 so users do not mistake installing the Phoenix dependency for registering an MCP client connection.

- update the maintained dependency constraint and repository URL
- document the separate Claude Code, Codex, and OpenCode registration steps
- mark Tidewave MCP registration as external for every runtime
- regenerate all four skills targets and reviewed snapshots from the canonical skill

## Verification

- `make ci`
- `make generated-skills-sync`
- `make eval`
- `make lint`
- `python3 -m pytest scripts/tests/ -q` (135 passed)

Authoritative setup was cross-checked against the current `tidewave-ai/tidewave_phoenix` README and MCP client guides.