### PR TITLE
fix(examples): improve skill routing recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,10 @@ capabilities rather than claiming cross-runtime feature parity.
 
 ### Fixed
 
+- **Examples skill routing** — clarify that requests for sample code, proper
+  implementations, walkthroughs, and expected workflow output should load the
+  examples skill alongside the relevant domain skill.
+
 - **Accurate Tidewave MCP setup boundary** — update the maintained Phoenix
   dependency requirement and repository link, distinguish exposing Tidewave's
   HTTP server from registering it with a client, and document external

--- a/plugins/elixir-phoenix/skills/examples/SKILL.md
+++ b/plugins/elixir-phoenix/skills/examples/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: examples
-description: "Provide Phoenix, LiveView, Ecto, OTP, or Oban examples and walkthroughs. Use for sample code, step-by-step guidance, or what an implementation/output looks like. NOT for debugging, direct implementation, best practices, or audits."
+description: "Provide Phoenix, LiveView, Ecto, OTP, or Oban examples. Use when asked for sample code, a walkthrough, a proper implementation, or expected workflow output. Pair with domain skills. NOT for debugging, direct changes, best-practice advice, or audits."
 effort: low
 ---
 

--- a/scripts/generated_target_snapshots.json
+++ b/scripts/generated_target_snapshots.json
@@ -4,22 +4,22 @@
     "amp": {
       "entries": 379,
       "files": 251,
-      "sha256": "0c7a901db6c9b6b4b7e8e3093f0564738f38ffedcda15a32b25323058559e4b7"
+      "sha256": "bc2457fffa9f93f25e5b5101db4512257f55fe2121ec340a382c29a3761ce8f3"
     },
     "codex": {
       "entries": 385,
       "files": 254,
-      "sha256": "bcb1c396d42aa1ec7fd5ae6d18db78ee8ca2eb306b2425aa41b1a3bb76e32a93"
+      "sha256": "fd1bd69334d9a1af202cc14f1d92318eb17622635f18fe1f7e587c3af6f08187"
     },
     "opencode": {
       "entries": 379,
       "files": 251,
-      "sha256": "594f1be7e12dea8fd8c9a92eb5cc4cde666d01970e1fd453af73789fd6aa6b79"
+      "sha256": "551f39bc514a37bad91c6624c30d1d6555b8f9ab24ecde1b9eb3b3d925069bcc"
     },
     "pi": {
       "entries": 380,
       "files": 252,
-      "sha256": "6036d2cb864e681aefd6da7d046c3e4e8beca2c56b58663d716199417b4c095a"
+      "sha256": "9b47366f5179676db750943d8af889a78b058502ddacdc08cdcf659cd9d7b639"
     }
   }
 }

--- a/targets/amp/skills/phx-examples/SKILL.md
+++ b/targets/amp/skills/phx-examples/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: phx-examples
-description: Provide Phoenix, LiveView, Ecto, OTP, or Oban examples and walkthroughs.
-  Use for sample code, step-by-step guidance, or what an implementation/output looks
-  like. NOT for debugging, direct implementation, best practices, or audits.
+description: Provide Phoenix, LiveView, Ecto, OTP, or Oban examples. Use when asked
+  for sample code, a walkthrough, a proper implementation, or expected workflow output.
+  Pair with domain skills. NOT for debugging, direct changes, best-practice advice,
+  or audits.
 ---
 
 # Examples & Walkthroughs

--- a/targets/codex/skills/phx-examples/SKILL.md
+++ b/targets/codex/skills/phx-examples/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: phx-examples
-description: Provide Phoenix, LiveView, Ecto, OTP, or Oban examples and walkthroughs.
-  Use for sample code, step-by-step guidance…
+description: Provide Phoenix, LiveView, Ecto, OTP, or Oban examples. Use when asked
+  for sample code, a walkthrough, a proper…
 ---
 
 # Examples & Walkthroughs

--- a/targets/opencode/skills/phx-examples/SKILL.md
+++ b/targets/opencode/skills/phx-examples/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: phx-examples
-description: Provide Phoenix, LiveView, Ecto, OTP, or Oban examples and walkthroughs.
-  Use for sample code, step-by-step guidance, or what an implementation/output looks
-  like. NOT for debugging, direct implementation, best practices, or audits.
+description: Provide Phoenix, LiveView, Ecto, OTP, or Oban examples. Use when asked
+  for sample code, a walkthrough, a proper implementation, or expected workflow output.
+  Pair with domain skills. NOT for debugging, direct changes, best-practice advice,
+  or audits.
 ---
 
 # Examples & Walkthroughs

--- a/targets/pi/skills/phx-examples/SKILL.md
+++ b/targets/pi/skills/phx-examples/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: phx-examples
-description: Provide Phoenix, LiveView, Ecto, OTP, or Oban examples and walkthroughs.
-  Use for sample code, step-by-step guidance, or what an implementation/output looks
-  like. NOT for debugging, direct implementation, best practices, or audits.
+description: Provide Phoenix, LiveView, Ecto, OTP, or Oban examples. Use when asked
+  for sample code, a walkthrough, a proper implementation, or expected workflow output.
+  Pair with domain skills. NOT for debugging, direct changes, best-practice advice,
+  or audits.
 ---
 
 # Examples & Walkthroughs


### PR DESCRIPTION
## Why

The complete v3 behavioral trigger gate found one failing skill: `examples` scored 70% against the required 75% minimum, with high precision but insufficient recall.

## What changed

- clarify that sample code, walkthroughs, proper implementations, and expected workflow output should load `examples`
- explicitly pair `examples` with relevant domain skills
- retain exclusions for debugging, direct changes, best-practice advice, and audits
- regenerate all four runtime targets and golden snapshots

## Verification

- original full gate: 51 skills, 96.17% average; only `examples` failed at 70%
- focused fresh rerun after the change: `examples` 80% accuracy, 100% precision, 60% recall
- structural score: 1.000
- `make ci`: 235 passed; eval and security scan passed
- generated drift checks and snapshots: passed for Amp, Codex, Pi, and OpenCode
- `git diff --check`: passed

No release or tag is included.
