### PR TITLE
fix(ci): enforce clean npm dependency audits

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -97,7 +97,7 @@ jobs:
         run: npm ci
 
       - name: npm audit
-        run: npm audit --omit=dev || true
+        run: npm audit --audit-level=high
 
   test:
     name: Python Tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,16 +75,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/character-entities": {
@@ -325,9 +325,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Fix the development-tool dependency alerts without changing the released plugin version.

- update `js-yaml` from 5.2.1 to 5.2.2
- update `brace-expansion` from 5.0.7 to 5.0.8
- audit development dependencies instead of omitting them
- fail CI on high or critical npm advisories instead of swallowing the exit code

Verification: `npm ci`, `npm audit --audit-level=high` (0 vulnerabilities), `npm test` (236 passed), and `make ci` all pass.

No plugin version bump or patch release is included.