### PR TITLE
docs(upgrade): warn that v2 → v3 needs the compat plugins first (#135)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -24,6 +24,7 @@ consistent. **Contributor tooling — not shipped in the plugin.**
 6. **ALWAYS leave a fresh empty `## [Unreleased]`** — one `[Unreleased]` becomes one version heading; re-add an empty one on top.
 7. **NEVER force-push** — `git push --force` is hook-blocked here. If history needs rewriting, the user runs it via `!`.
 8. **EVERY release body links the docs site** — append the `https://phxagents.dev` footer. Releases are this project's one measured promotion lever (v3.0.1: 51 → 120 cloners in a day).
+9. **UPGRADE-BREAKING RELEASES LEAD WITH THE WARNING** — if users must do anything beyond `/plugin update`, the release body opens with a `> [!WARNING]` block carrying the exact commands (see #135).
 
 ## Step 0: Preconditions
 
@@ -117,8 +118,8 @@ gh release create vX.Y.Z --title "vX.Y.Z — <summary>" --notes-file <changelog-
 ```
 
 Use the new CHANGELOG section as release notes (extract it to a temp file or `--notes`),
-then **append the docs footer** before publishing — a release body is read at the
-moment someone decides whether to install:
+then **prepend any upgrade warning** (Iron Law 9) and **append the docs footer** before
+publishing — a release body is read at the moment someone decides whether to install:
 
 ```
 ---

--- a/.claude/skills/release/references/templates.md
+++ b/.claude/skills/release/references/templates.md
@@ -57,6 +57,32 @@ printf '\n---\n\nDocs, install guides, and the runtime compatibility matrix: <ht
 gh release create vX.Y.Z --title "vX.Y.Z — <summary>" --notes-file /tmp/relnotes.md
 ```
 
+## Upgrade warning block (Iron Law 9)
+
+When the release requires anything beyond `/plugin update` — a new dependency,
+a renamed manifest, a manual migration — **prepend** this block so it is the
+first thing on the release page, above the changelog body:
+
+```bash
+cat > /tmp/relnotes.md <<'EOF'
+> [!WARNING]
+> **Upgrading from vN.x requires these commands in this order.** <one line on
+> what breaks otherwise, in user-visible terms.>
+>
+> ```bash
+> <exact commands>
+> ```
+
+EOF
+awk '/^## \[X\.Y\.Z\]/{f=1} f&&/^## \[/&&!/X\.Y\.Z/{exit} f' CHANGELOG.md >> /tmp/relnotes.md
+```
+
+State the blast radius in what the user loses, not in mechanism. "The plugin
+fails to load — all 36 `/phx:*` commands disappear" lands; "enters a
+missing-dependency state" does not. v3.0.0 used the second phrasing, buried in
+a `### Changed` bullet, and users still upgraded into a broken install
+(issue #135).
+
 Title format matches history: `vX.Y.Z — <short summary>` (em dash).
 
 **The docs footer is not optional.** A release body is read at the exact moment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,16 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   subagents were never affected — their own frontmatter wins — so
   `parallel-reviewer` and `planning-orchestrator` needed no change.
 
+- **The `release` contributor skill hoists upgrade warnings to the top of the
+  release body** — a new Iron Law and template: when a release needs anything
+  beyond `/plugin update`, the body opens with a `> [!WARNING]` block carrying
+  the exact commands, and states the blast radius in what the user loses rather
+  than in mechanism. v3.0.0 documented its staged upgrade correctly but placed
+  it at roughly line 145 of a long changelog dump, phrased as "a temporary
+  missing-dependency state" — and users upgraded into a broken install anyway
+  (#135). A correct instruction nobody reaches is indistinguishable from a
+  missing one.
+
 - **CLAUDE.md model-tier rules describe the actual split** — the guidance said
   "opus for primary workflow orchestrators, sonnet for secondary orchestrators
   (investigation, tracing)", which stopped matching the plugin once
@@ -59,6 +69,35 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `general-purpose` pinning requirement that follows from it.
 
 ### Fixed
+
+- **Upgrading from v2.x no longer lands users in a dead install** (reported by
+  @barquesurlocean, #135) — v3.0.0 renamed the plugin manifest to `phx` (which
+  is what makes `/phx:*` correct; pre-v3 versions namespaced their commands as
+  `/elixir-phoenix:*` while `/phx:init` wrote `/phx:*` into `CLAUDE.md`) and in
+  the same commit introduced the `ecto` and `lv` compatibility plugins as
+  manifest `dependencies`. Adding a dependency turns out to be a breaking
+  change for already-installed users: `claude plugin update` does **not**
+  install dependencies a new version newly declares, and a missing dependency
+  is a hard load failure, so the obvious `/plugin update` leaves the plugin at
+  `✘ failed to load` with all 36 `/phx:*` commands gone — taken down by the 3
+  compatibility commands. Verified on Claude Code 2.1.234, so this is not the
+  2.1.76–2.1.109 version band recorded during #130; it affects every v2 user on
+  every Claude Code version. Nothing self-heals either, because auto-update is
+  off by default for non-Anthropic marketplaces. The README's staged upgrade
+  block was already correct but described the failure as "a missing-dependency
+  state"; it now leads with a warning, states the blast radius in commands
+  lost, declares the 2.1.110 version floor, adds a recovery path for anyone who
+  already updated in the wrong order, and explains the `/phx:` vs
+  `/elixir-phoenix:` prefix history. Note during recovery that
+  `claude plugin install elixir-phoenix@oliver-kriska` resolves only **one**
+  missing dependency per invocation.
+
+- **`make validate` covers every plugin manifest** — the target validated
+  `plugins/elixir-phoenix` and the marketplace only, so `plugins/ecto`,
+  `plugins/lv`, and `plugins/catchup` could ship a schema violation that CI
+  never saw. This is exactly how `displayName` reached users: it was present in
+  all four Claude-facing manifests while the gate looked at one of them. All
+  five manifests are validated now.
 
 - **`displayName` removed from all Claude Code manifests** (reported by
   @ndrean, #130) — the field was introduced alongside the v3 plugin split and

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,11 @@ test-quick: ## Run pytest (no verbose, fast)
 
 # --- Validate ---
 
-validate: ## Run claude plugin validate on plugin + marketplace manifests
+validate: ## Run claude plugin validate on every plugin + marketplace manifest
 	@claude plugin validate plugins/elixir-phoenix
+	@claude plugin validate plugins/ecto
+	@claude plugin validate plugins/lv
+	@claude plugin validate plugins/catchup
 	@claude plugin validate .
 
 amp-skills: ## Generate Amp skills from the canonical Claude plugin

--- a/README.md
+++ b/README.md
@@ -140,18 +140,23 @@ that prevent the mistakes Elixir developers actually make in production.
 /plugin install elixir-phoenix
 ```
 
-The install name stays `elixir-phoenix`, while its public workflow commands
-remain `/phx:*`. Claude Code now derives plugin command names from the plugin
-namespace and each skill's final command name. On a fresh install, it also pulls
-in two small compatibility namespaces for `/ecto:*` and `/lv:*` automatically;
-you do not need to install them separately. Existing v2 installations should
-follow the staged upgrade below. After an update, run `/reload-plugins` before
-trying the commands in an already-open session.
+Requires **Claude Code 2.1.110 or newer**. The install name stays
+`elixir-phoenix`, while its public workflow commands remain `/phx:*` — Claude
+Code namespaces commands by the plugin's manifest name, not its install name.
+A fresh install also pulls in two small compatibility namespaces for `/ecto:*`
+and `/lv:*` automatically; you do not need to install them separately. After an
+update, run `/reload-plugins` before trying the commands in an already-open
+session.
 
 #### Updating from v2.x
 
-Update the marketplace, install the two compatibility namespaces introduced in
-v3, then update the main plugin:
+> [!WARNING]
+> **Do not run `claude plugin update` on its own.** v3 introduced two
+> compatibility plugins (`ecto`, `lv`) that v2 never declared, and
+> `claude plugin update` does not install dependencies a new version newly
+> declares. The updated plugin then fails to load entirely — you lose all 36
+> `/phx:*` commands, not just `/ecto:*` and `/lv:*`. Install the two
+> compatibility plugins **first**, using the exact order below.
 
 ```bash
 claude plugin marketplace update oliver-kriska
@@ -160,11 +165,33 @@ claude plugin install lv@oliver-kriska
 claude plugin update elixir-phoenix@oliver-kriska
 ```
 
-Installing the compatibility plugins first prevents the updated main plugin
-from entering a missing-dependency state. Restart Claude Code afterward. In an
-already-open session, `/reload-plugins` reloads the updated skills, agents, and
-hooks. Confirm that `/phx:help`, `/ecto:n1-check`, and `/lv:assigns` appear
-before continuing work.
+Restart Claude Code afterward. In an already-open session, `/reload-plugins`
+reloads the updated skills, agents, and hooks. Confirm that `/phx:help`,
+`/ecto:n1-check`, and `/lv:assigns` appear before continuing work.
+
+##### Already updated in the wrong order?
+
+If `claude plugin list` reports `✘ failed to load` with
+`Dependency "ecto@oliver-kriska" is not installed`, install the two
+compatibility plugins to recover — nothing is lost, and no reinstall is needed:
+
+```bash
+claude plugin install ecto@oliver-kriska
+claude plugin install lv@oliver-kriska
+```
+
+Note that `claude plugin install elixir-phoenix@oliver-kriska` also repairs the
+state, but resolves only **one** missing dependency per run, so it needs two
+invocations here.
+
+#### Commands are `/phx:*`, not `/elixir-phoenix:*`
+
+Plugin versions before v3.0.0 shipped a manifest named `elixir-phoenix`, so
+their commands resolved as `/elixir-phoenix:work` even though `/phx:init` wrote
+`/phx:*` into `CLAUDE.md`. v3.0.0 renamed the manifest to `phx`, which is what
+makes `/phx:*` correct. If Claude Code reports `/phx:` commands as unknown,
+you are on a pre-v3 version — follow the upgrade steps above, then re-run
+`/phx:init --update`.
 
 #### Claude Code subagent compatibility
 


### PR DESCRIPTION
Closes #135 once released.

## The reported bug

Claude Code namespaces plugin commands by the manifest `name`, not the install name. Through v2.14.3 the manifest said `"name": "elixir-phoenix"`, so commands resolved as `/elixir-phoenix:work` while `/phx:init` wrote `/phx:*` into `CLAUDE.md`. The plugin never shipped a `commands/` directory, so this was wrong for the whole v1/v2 line.

Already fixed in v3.0.0 (`918f809`) by renaming the manifest to `phx`. No code change needed here.

## The bug that was actually still live

Checking the upgrade path turned up a second defect. v3 declares `ecto` and `lv` as manifest `dependencies`, and **`claude plugin update` does not install dependencies that a new version newly declares**. Because a missing dependency is a hard load failure, updating in place gives:

```
claude plugin update elixir-phoenix@oliver-kriska
✔ Plugin "elixir-phoenix" updated from 2.13.0 to 3.0.1

claude plugin list
❯ elixir-phoenix@oliver-kriska
  Status: ✘ failed to load
  Error: Dependency "ecto@oliver-kriska" is not installed
```

All 36 `/phx:*` commands disappear — taken down by the 3 compatibility commands. Reproduced on Claude Code **2.1.234** in an isolated `CLAUDE_CONFIG_DIR`, so this is not the 2.1.76–2.1.109 band found during #130; it affects every v2 user on every Claude Code version. Nothing self-heals, since auto-update is off by default for non-Anthropic marketplaces.

Also found: `claude plugin install <dependent>` resolves only **one** missing dependency per invocation, so recovery needs two runs here.

## Changes

- **`README.md`** — the staged upgrade block was already correct but described the failure as "a missing-dependency state" and sat below the fold. It now leads with a `> [!WARNING]`, states the blast radius in commands lost, declares the 2.1.110 Claude Code floor, adds a recovery path for anyone who already updated in the wrong order, and explains the `/phx:` vs `/elixir-phoenix:` history for people searching the old prefix.
- **`.claude/skills/release/`** — new Iron Law 9 plus a template: upgrade-breaking releases open with the warning block carrying exact commands, phrased as what the user loses rather than as mechanism. v3.0.0 documented its staged upgrade at ~line 145 of a long changelog dump and users upgraded into a broken install anyway.
- **`Makefile`** — `make validate` now covers all five manifests (`elixir-phoenix`, `ecto`, `lv`, `catchup`, marketplace) instead of two. That gap is how `displayName` shipped in four manifests while CI checked one.
- **`CHANGELOG.md`** — two Fixed entries, one Changed entry under `[Unreleased]`.

Doc-only, so no version bump — this folds into the next release.

## Verification

`make ci` green: 236 tests, 5 manifests validated, 51 skills / 26 agents (avg 0.990 / 1.000), security scan clean.

Upgrade paths verified end-to-end in isolated config dirs on 2.1.234: broken-order repro, staged-order success, and both recovery paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)