### PR TITLE
fix(amp): replace the impossible phx-watch-pr install command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,27 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The `phx-watch-pr` harness test was one second from red** — it ran with a
+  60-second subprocess timeout and takes ~59 seconds of wall time for ~3 seconds
+  of CPU: the harness drives a fake clock with real 80ms flushes, and `advance()`
+  performs up to 21 of them across 23 calls. Observed locally at 58.9s, 60.4s,
+  and 73.9s on consecutive runs, so it passes or fails on runner load alone —
+  and it is a required check, meaning it would have started blocking unrelated
+  PRs. Raised to 240s; the harness itself is unchanged, since shortening the
+  flush would trade a timeout flake for a race.
+
+- **The `phx-watch-pr` install command could never have worked** — README and
+  `docs/amp.md` told users to run `amp plugins add` against a
+  `raw.githubusercontent.com` URL. Amp `0.0.1787045288` rejects that with
+  `For now, only https://ampcode.com/@amp/plugins/*.ts ... URLs are allowed` and
+  writes nothing. The same `docs/amp.md` already said, 390 lines further down,
+  that "Amp currently restricts `amp plugins add` ... to Amp-hosted plugins" —
+  the file contradicted itself, and the install instruction was the wrong half.
+  Both call sites now use the atomic `curl` + `mv` pattern already documented
+  for `elixir-phoenix.ts`, pointing at the standalone repository's `stable`
+  branch. The update section covers both plugins instead of only the workflow
+  one.
+
 - **Upgrading from v2.x no longer lands users in a dead install** (reported by
   @barquesurlocean, #135) — v3.0.0 renamed the plugin manifest to `phx` (which
   is what makes `/phx:*` correct; pre-v3 versions namespaced their commands as

--- a/README.md
+++ b/README.md
@@ -306,13 +306,17 @@ hosted artifacts are managed through Amp's Personal Settings or personal Git
 repositories and work across machines and orbs. See the complete [Amp guide](docs/amp.md)
 for hosted publication, source precedence, wrapper limits, updates, fallback
 installation, specialists, safety boundaries, and verification.
+
 `phx-watch-pr` additionally needs the separate `phx-watch-pr.ts` plugin.
 Install it into the project where the worker Orb opens and watches PRs:
 
 ```bash
-amp plugins add \
-  https://raw.githubusercontent.com/oliver-kriska/claude-elixir-phoenix/main/targets/amp/plugins/phx-watch-pr.ts \
-  --target workspace
+mkdir -p .amp/plugins
+plugin=".amp/plugins/phx-watch-pr.ts"
+temporary="$(mktemp "${plugin}.XXXXXX")"
+curl --fail --silent --show-error --location \
+  https://raw.githubusercontent.com/oliver-kriska/amp-elixir-phoenix/stable/plugins/phx-watch-pr.ts \
+  --output "$temporary" && mv "$temporary" "$plugin"
 ```
 
 It holds a bounded Orb keep-alive lease, filters deployment-like checks out of

--- a/docs/amp.md
+++ b/docs/amp.md
@@ -112,9 +112,12 @@ generated Amp plugin because only the Plugin API can hold an Orb keep-alive
 lease and wake the same thread after inactivity:
 
 ```bash
-amp plugins add \
-  https://raw.githubusercontent.com/oliver-kriska/claude-elixir-phoenix/main/targets/amp/plugins/phx-watch-pr.ts \
-  --target workspace
+mkdir -p .amp/plugins
+plugin=".amp/plugins/phx-watch-pr.ts"
+temporary="$(mktemp "${plugin}.XXXXXX")"
+curl --fail --silent --show-error --location \
+  https://raw.githubusercontent.com/oliver-kriska/amp-elixir-phoenix/stable/plugins/phx-watch-pr.ts \
+  --output "$temporary" && mv "$temporary" "$plugin"
 ```
 
 Start a fresh Amp process or run `plugins: reload`. Plugins execute code; audit
@@ -501,18 +504,22 @@ normal update path, but removal followed by installation is the exact-sync path
 when a release deletes or renames a skill.
 
 Amp currently restricts `amp plugins add` and directive-based auto-updates to
-Amp-hosted plugins. Update this GitHub-hosted plugin by downloading the current
-validated file again, or remove it with Amp:
+Amp-hosted plugins; it rejects any other URL outright. Update these
+GitHub-hosted plugins by downloading the current validated file again, or remove
+them with Amp:
 
 ```bash
-# Update the workspace plugin atomically
-plugin=".amp/plugins/elixir-phoenix.ts"
-temporary="$(mktemp "${plugin}.XXXXXX")"
-curl --fail --silent --show-error --location \
-  https://raw.githubusercontent.com/oliver-kriska/amp-elixir-phoenix/stable/plugins/elixir-phoenix.ts \
-  --output "$temporary" && mv "$temporary" "$plugin"
+# Update a workspace plugin atomically
+for name in elixir-phoenix phx-watch-pr; do
+  plugin=".amp/plugins/${name}.ts"
+  [ -f "$plugin" ] || continue
+  temporary="$(mktemp "${plugin}.XXXXXX")"
+  curl --fail --silent --show-error --location \
+    "https://raw.githubusercontent.com/oliver-kriska/amp-elixir-phoenix/stable/plugins/${name}.ts" \
+    --output "$temporary" && mv "$temporary" "$plugin"
+done
 
-# Remove the workspace-scoped installation
+# Remove a workspace-scoped installation
 amp plugins remove elixir-phoenix.ts --target workspace
 ```
 

--- a/scripts/tests/test_amp.py
+++ b/scripts/tests/test_amp.py
@@ -443,7 +443,10 @@ def test_native_watch_plugin_lifecycle_harness(tmp_path) -> None:
         cwd=Path(__file__).parents[2],
         text=True,
         capture_output=True,
-        timeout=60,
+        # The harness drives a fake clock with real 80ms flushes: advance() runs
+        # up to 21 of them and is called 23 times, so the run is ~59s of waiting
+        # against ~3s of CPU. A 60s limit left under a second of margin.
+        timeout=240,
     )
 
     assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
## Summary

Post-merge fixes for #132, from an Amp review of the merged `main` plus one
issue found while verifying it.

## 1. The watcher install command could never have worked

README and `docs/amp.md` both told users to run:

```bash
amp plugins add https://raw.githubusercontent.com/.../phx-watch-pr.ts --target workspace
```

Amp rejects this outright (verified on `0.0.1787045288`):

```
Error: For now, only https://ampcode.com/@amp/plugins/*.ts and
https://ampcode.com/@amp/plugins/*.ts URLs are allowed.
```

Nothing is written. `docs/amp.md` already contradicted itself — 390 lines below
the install block it states Amp "restricts `amp plugins add` ... to Amp-hosted
plugins" and hands out an atomic `curl` for `elixir-phoenix.ts`. The install
instruction was the wrong half of that contradiction.

Both call sites now use the same `curl` + `mv` pattern against the standalone
repository's `stable` branch. Verified end to end: the documented command
fetches 43,318 bytes byte-identical to `targets/amp/plugins/phx-watch-pr.ts`.
The update section now loops over both plugins instead of only the workflow one.

## 2. The `phx-watch-pr` harness was one second from red

It ran with a 60s subprocess timeout and takes ~59s wall for ~3s CPU: the
harness drives a fake clock with real 80ms flushes, and `advance()` performs up
to 21 of them across 23 calls. Three consecutive local runs took **58.9s, 60.4s,
and 73.9s** — a required check passing or failing on runner load alone, which
would have started blocking unrelated PRs.

Raised to 240s. The harness is unchanged; shortening the flush would trade a
timeout flake for a race.

## 3. Paragraph join

Fixes a missing blank line in README introduced when the watch-pr block was
merged forward in #132.

## Verification

`make ci` — **246 passed**, all five manifests validated, all four generated
targets drift-clean, snapshots match, eval passed (51 skills avg 0.990, 26
agents 1.000).

## Not in this PR

- The standalone distribution is stale: `amp-elixir-phoenix` `stable` still
  serves the pre-compaction 98,905-byte `elixir-phoenix.ts` (canonical is
  95,191, under the 96,000 transport budget) and three skills differ. Needs a
  fresh sync from `7c613bd`.
- `Notify Docs Site` fails with **Bad credentials** (401) — `SITE_DISPATCH_TOKEN`
  is invalid or expired and needs regenerating, not rescoping.