### PR TITLE
fix(amp): route remote specialist children to orbs

### DIFF
--- a/docs/amp.md
+++ b/docs/amp.md
@@ -315,7 +315,7 @@ only `Read` and `finder`. They cannot edit or create files, run shell commands,
 or invoke more agents.
 
 Choose `phx: specialist` to select one specialist, enter its task, and run it in
-a local child thread. The result is returned to the current thread for evidence
+a child thread. The result is returned to the current thread for evidence
 checking and synthesis. If no thread exists yet, the command creates and shows a
 medium-mode parent thread first.
 
@@ -335,10 +335,14 @@ single failed track from discarding successful results. The parent verifies and
 deduplicates findings; failed concerns fall back to sequential analysis rather
 than being respawned.
 
-Child threads use Amp's `local` executor and are linked to the parent thread.
-Starting the plugin does not run a model. A model is billed only when a
-specialist command or tool actually runs, once per selected child plus the
-normal parent synthesis turn.
+Child threads are linked to the parent thread. From a local Amp client they use
+that client's executor and checkout. From an Orb they run in fresh child Orbs,
+because Amp does not expose a same-Orb child executor. Those children receive
+the collected project context but do not share the parent's processes,
+services, or uncommitted working tree. Starting the plugin does not run a model.
+A specialist command or tool runs one model call per selected child plus the
+normal parent synthesis turn; remote runs also consume child Orb time and run
+the project's Orb setup.
 
 ### Choose the specialist model
 

--- a/scripts/port_lib/amp.py
+++ b/scripts/port_lib/amp.py
@@ -99,7 +99,7 @@ complete.
 
 For a non-trivial failure with independent reproduction, root-cause, impact,
 and fix-strategy questions, call `elixir_phoenix_parallel_investigate` once.
-Its four local child threads are enforced read-only (`Read` and `finder` only).
+Its four child threads are enforced read-only (`Read` and `finder` only).
 Reconcile their output in this parent thread and verify every claimed evidence
 path before editing. If the tool is unavailable or a child fails, run only the
 missing track sequentially. Simple failures should stay sequential.
@@ -807,6 +807,10 @@ function errorText(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+function childExecutor(amp: PluginAPI): 'local' | 'orb' {
+  return amp.system.executor.kind === 'remote' ? 'orb' : 'local'
+}
+
 function specialistTask(
   definition: SpecialistDefinition,
   scope: string,
@@ -845,6 +849,7 @@ async function runChildren(
   agents: Map<string, Agent>,
   prompt: (definition: { key: string; label: string }) => string,
   parentThreadID: PluginThread['id'],
+  executor: 'local' | 'orb',
 ): Promise<ChildResult[]> {
   const settled = await Promise.allSettled(
     definitions.map(async (definition) => {
@@ -852,7 +857,7 @@ async function runChildren(
       if (!agent) throw new Error(`Agent is unavailable: ${definition.key}`)
       const result = await agent.run(prompt(definition), {
         parentThreadID,
-        executor: 'local',
+        executor,
         timeoutMs: childTimeoutMs,
       })
       return {
@@ -918,7 +923,7 @@ async function ensureThread(
 ): Promise<PluginThread> {
   if (ctx.thread) return ctx.thread
   return amp.getBuiltinAgent('medium').createThread({
-    executor: 'local',
+    executor: childExecutor(amp),
     show: true,
   })
 }
@@ -1251,6 +1256,7 @@ export default function (amp: PluginAPI) {
               projectContext,
             ),
           ctx.thread.id,
+          childExecutor(amp),
         )
         return aggregateResults(
           'Parallel Elixir/Phoenix Review Results',
@@ -1303,6 +1309,7 @@ export default function (amp: PluginAPI) {
               projectContext,
             ),
           ctx.thread.id,
+          childExecutor(amp),
         )
         return aggregateResults(
           'Parallel Elixir/Phoenix Investigation Results',
@@ -1349,6 +1356,7 @@ export default function (amp: PluginAPI) {
               projectContext,
             ),
           thread.id,
+          childExecutor(amp),
         )
         await thread.appendUserMessage({
           type: 'user-message',
@@ -1393,6 +1401,7 @@ export default function (amp: PluginAPI) {
               projectContext,
             ),
           thread.id,
+          childExecutor(amp),
         )
         await thread.appendUserMessage({
           type: 'user-message',
@@ -1436,6 +1445,7 @@ export default function (amp: PluginAPI) {
               projectContext,
             ),
           thread.id,
+          childExecutor(amp),
         )
         await thread.appendUserMessage({
           type: 'user-message',

--- a/scripts/tests/amp_plugin_harness.ts
+++ b/scripts/tests/amp_plugin_harness.ts
@@ -31,6 +31,7 @@ const commands = new Map<string, Function>()
 const tools = new Map<string, any>()
 const handlers = new Map<string, Function>()
 const agents: any[] = []
+const childRunOptions: Array<{ name: string; options: any }> = []
 const notices: string[] = []
 let config: Record<string, unknown> = {}
 let configError = false
@@ -51,7 +52,8 @@ const amp: any = {
   createAgent(definition: any) {
     const agent = {
       definition,
-      async run() {
+      async run(_prompt: string, options: any) {
+        childRunOptions.push({ name: definition.name, options })
         if (definition.name.includes(childFailure)) {
           throw new Error(`simulated ${definition.name} failure`)
         }
@@ -107,7 +109,7 @@ const amp: any = {
       return typeof value === 'string' ? value : value.path
     },
   },
-  system: { workspaceRoot: workspace },
+  system: { workspaceRoot: workspace, executor: { kind: 'local' } },
   activeThread: { current: undefined },
   logger: { log() {} },
   ui: {
@@ -266,6 +268,39 @@ assert.match(
   parallelResult,
   /simulated elixir-phoenix-security-analyzer failure/,
 )
+assert.ok(childRunOptions.length > 0)
+assert.ok(
+  childRunOptions.every(
+    ({ options }) =>
+      options.executor === 'local' &&
+      options.parentThreadID === 'T-parent' &&
+      options.timeoutMs === 300_000,
+  ),
+)
+
+childRunOptions.length = 0
+childFailure = 'never-fail'
+amp.system.executor.kind = 'remote'
+await parallel.execute(
+  { scope: 'review changes', specialists: ['elixir'] },
+  { thread: { id: 'T-remote-parent' } },
+)
+assert.equal(childRunOptions.length, 1)
+assert.deepEqual(childRunOptions[0].options, {
+  parentThreadID: 'T-remote-parent',
+  executor: 'orb',
+  timeoutMs: 300_000,
+})
+
+childRunOptions.length = 0
+amp.system.executor.kind = 'unknown'
+await parallel.execute(
+  { scope: 'review changes', specialists: ['ecto'] },
+  { thread: { id: 'T-unknown-parent' } },
+)
+assert.equal(childRunOptions.length, 1)
+assert.equal(childRunOptions[0].options.executor, 'local')
+amp.system.executor.kind = 'local'
 
 const notify = async (message: string) => {
   notices.push(message)

--- a/scripts/tests/test_amp.py
+++ b/scripts/tests/test_amp.py
@@ -145,7 +145,8 @@ def test_builds_complete_target_with_public_workflow_commands(tmp_path) -> None:
     assert "tools: ['Read', 'finder']" in plugin
     assert "Promise.allSettled" in plugin
     assert "parentThreadID" in plugin
-    assert "executor: 'local'" in plugin
+    assert "amp.system.executor.kind === 'remote' ? 'orb' : 'local'" in plugin
+    assert "executor: childExecutor(amp)" in plugin
     assert "name: 'elixir_phoenix_parallel_review'" in plugin
     assert "name: 'elixir_phoenix_parallel_investigate'" in plugin
     assert "amp.on('tool.call'" in plugin

--- a/targets/amp/plugins/elixir-phoenix.ts
+++ b/targets/amp/plugins/elixir-phoenix.ts
@@ -221,6 +221,10 @@ function errorText(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+function childExecutor(amp: PluginAPI): 'local' | 'orb' {
+  return amp.system.executor.kind === 'remote' ? 'orb' : 'local'
+}
+
 function specialistTask(
   definition: SpecialistDefinition,
   scope: string,
@@ -259,6 +263,7 @@ async function runChildren(
   agents: Map<string, Agent>,
   prompt: (definition: { key: string; label: string }) => string,
   parentThreadID: PluginThread['id'],
+  executor: 'local' | 'orb',
 ): Promise<ChildResult[]> {
   const settled = await Promise.allSettled(
     definitions.map(async (definition) => {
@@ -266,7 +271,7 @@ async function runChildren(
       if (!agent) throw new Error(`Agent is unavailable: ${definition.key}`)
       const result = await agent.run(prompt(definition), {
         parentThreadID,
-        executor: 'local',
+        executor,
         timeoutMs: childTimeoutMs,
       })
       return {
@@ -332,7 +337,7 @@ async function ensureThread(
 ): Promise<PluginThread> {
   if (ctx.thread) return ctx.thread
   return amp.getBuiltinAgent('medium').createThread({
-    executor: 'local',
+    executor: childExecutor(amp),
     show: true,
   })
 }
@@ -665,6 +670,7 @@ export default function (amp: PluginAPI) {
               projectContext,
             ),
           ctx.thread.id,
+          childExecutor(amp),
         )
         return aggregateResults(
           'Parallel Elixir/Phoenix Review Results',
@@ -717,6 +723,7 @@ export default function (amp: PluginAPI) {
               projectContext,
             ),
           ctx.thread.id,
+          childExecutor(amp),
         )
         return aggregateResults(
           'Parallel Elixir/Phoenix Investigation Results',
@@ -763,6 +770,7 @@ export default function (amp: PluginAPI) {
               projectContext,
             ),
           thread.id,
+          childExecutor(amp),
         )
         await thread.appendUserMessage({
           type: 'user-message',
@@ -807,6 +815,7 @@ export default function (amp: PluginAPI) {
               projectContext,
             ),
           thread.id,
+          childExecutor(amp),
         )
         await thread.appendUserMessage({
           type: 'user-message',
@@ -850,6 +859,7 @@ export default function (amp: PluginAPI) {
               projectContext,
             ),
           thread.id,
+          childExecutor(amp),
         )
         await thread.appendUserMessage({
           type: 'user-message',

--- a/targets/amp/skills/phx-investigate/SKILL.md
+++ b/targets/amp/skills/phx-investigate/SKILL.md
@@ -107,7 +107,7 @@ appropriate. Do not invoke another skill unless the user asks you to continue.
 
 For a non-trivial failure with independent reproduction, root-cause, impact,
 and fix-strategy questions, call `elixir_phoenix_parallel_investigate` once.
-Its four local child threads are enforced read-only (`Read` and `finder` only).
+Its four child threads are enforced read-only (`Read` and `finder` only).
 Reconcile their output in this parent thread and verify every claimed evidence
 path before editing. If the tool is unavailable or a child fails, run only the
 missing track sequentially. Simple failures should stay sequential.


### PR DESCRIPTION
## Summary
- route Amp specialist child threads to fresh Orbs when the parent executor is remote
- retain local child execution for local and unknown executor kinds
- document remote child isolation and Orb usage
- extend the generated plugin behavior harness and keep the committed Amp target in sync

## Verification
- `python -m pytest scripts/tests/test_amp.py -v --tb=short` — 22 passed
- `python -m scripts.build_amp_skills --check` — 51 skills and 2 plugins, no drift